### PR TITLE
enhencement: Add OnGetCellEditor event

### DIFF
--- a/source/hpp/Win32/Release/ovctable.hpp
+++ b/source/hpp/Win32/Release/ovctable.hpp
@@ -93,6 +93,7 @@ protected:
 	Ovctcmmn::TColNotifyEvent FEnteringColumn;
 	Ovctcmmn::TRowNotifyEvent FEnteringRow;
 	Ovctcmmn::TCellDataNotifyEvent FGetCellData;
+	Ovctcmmn::TCellEditorNotifyEvent FGetCellEditor;
 	Ovctcmmn::TCellAttrNotifyEvent FGetCellAttributes;
 	Ovctcmmn::TColNotifyEvent FLeavingColumn;
 	Ovctcmmn::TRowNotifyEvent FLeavingRow;
@@ -225,6 +226,7 @@ protected:
 	virtual void __fastcall DoGetCellAttributes(int RowNum, int ColNum, Ovctcmmn::TOvcCellAttributes &CellAttr);
 	virtual void __fastcall DoGetRowAttributes(int RowNum, Ovctcmmn::TOvcRowAttributes &CellAttr);
 	virtual void __fastcall DoGetCellData(int RowNum, int ColNum, void * &Data, Ovctcmmn::TOvcCellDataPurpose Purpose);
+	virtual void __fastcall DoGetCellEditor(int RowNum, int ColNum, Ovctcell::TOvcBaseTableCell* &CellEditor);
 	virtual void __fastcall DoLeavingColumn(int ColNum);
 	virtual void __fastcall DoLeavingRow(int RowNum);
 	virtual void __fastcall DoLockedCellClick(int RowNum, int ColNum);
@@ -358,6 +360,7 @@ protected:
 	__property Ovctcmmn::TColNotifyEvent OnEnteringColumn = {read=FEnteringColumn, write=FEnteringColumn};
 	__property Ovctcmmn::TRowNotifyEvent OnEnteringRow = {read=FEnteringRow, write=FEnteringRow};
 	__property Ovctcmmn::TCellDataNotifyEvent OnGetCellData = {read=FGetCellData, write=FGetCellData};
+	__property Ovctcmmn::TCellEditorNotifyEvent OnGetCellEditor = {read=FGetCellEditor, write=FGetCellEditor};
 	__property Ovctcmmn::TCellAttrNotifyEvent OnGetCellAttributes = {read=FGetCellAttributes, write=FGetCellAttributes};
 	__property Ovctcmmn::TRowAttrNotifyEvent OnGetRowAttributes = {read=FOnGetRowAttributes, write=FOnGetRowAttributes};
 	__property Ovctcmmn::TColNotifyEvent OnLeavingColumn = {read=FLeavingColumn, write=FLeavingColumn};
@@ -499,6 +502,7 @@ __published:
 	__property OnEnteringRow;
 	__property OnExit;
 	__property OnGetCellData;
+	__property OnGetCellEditor;
 	__property OnGetCellAttributes;
 	__property OnGetRowAttributes;
 	__property OnKeyDown;

--- a/source/hpp/Win32/Release/ovctcmmn.hpp
+++ b/source/hpp/Win32/Release/ovctcmmn.hpp
@@ -275,6 +275,8 @@ typedef void __fastcall (__closure *TRowResizeEvent)(System::TObject* Sender, in
 
 typedef void __fastcall (__closure *TCellNotifyEvent)(System::TObject* Sender, int RowNum, int ColNum);
 
+typedef void __fastcall (__closure *TCellEditorNotifyEvent)(System::TObject* Sender, int RowNum, int ColNum, TOvcTableCellAncestor* &CellEditor);
+
 typedef void __fastcall (__closure *TCellDataNotifyEvent)(System::TObject* Sender, int RowNum, int ColNum, void * &Data, TOvcCellDataPurpose Purpose);
 
 typedef void __fastcall (__closure *TCellAttrNotifyEvent)(System::TObject* Sender, int RowNum, int ColNum, TOvcCellAttributes &CellAttr);

--- a/source/ovctcmmn.pas
+++ b/source/ovctcmmn.pas
@@ -310,6 +310,9 @@ type
     NewHeight: Integer) of object;
   TCellNotifyEvent = procedure (Sender : TObject;
                                 RowNum : TRowNum; ColNum : TColNum) of object;
+  TCellEditorNotifyEvent = procedure(Sender: TObject;
+                               RowNum: integer; ColNum: integer;
+                               var CellEditor: TOvcTableCellAncestor) of object;
   TCellDataNotifyEvent = procedure (Sender : TObject;
                                     RowNum : TRowNum; ColNum : TColNum;
                                     var Data : pointer;


### PR DESCRIPTION
With this patch it's possible to change the cell Editor on the fly.
Two use cases:
     - cell editor can now depend on the data in the cell
     - the table widget has has problem to find the cell editors if you use it in a "frame in a frame"

regards
Henner Kollmann