### PR TITLE
Fix potential Access Violation

### DIFF
--- a/source/ovcfiler.pas
+++ b/source/ovcfiler.pas
@@ -427,7 +427,8 @@ begin
     S := ReadString(Section, Item, '1')
   else
     S := ReadString(Section, Item, '0');
-  Result := S[1] = '1';
+  
+  Result := Copy(S, 1, 1) = '1';
 end;
 
 function TOvcAbstractStore.ReadInteger(const Section, Item : string; DefaultValue : Integer) : Integer;


### PR DESCRIPTION
If S is an empty string the previous code would result in an Access Violation.
An alternative solution is simply:
Result := S = '1';
Which one do you prefer?