### PR TITLE
Fixes for 64bit Windows, mouse wheel scrolling and Touch gestures

### DIFF
--- a/source/O32Flxed.pas
+++ b/source/O32Flxed.pas
@@ -458,9 +458,9 @@ function TFlexEditStrings.Get(Index: Integer): string;
 var
   Text: array[0..4095] of Char;
 begin
-  Word((@Text)^) := SizeOf(Text);
+  Word((@Text)^) := Length(Text);
   SetString(Result, Text, SendMessage(FlexEdit.Handle, EM_GETLINE, Index,
-    NativeInt(@Text)));
+    lParam(@Text)));
 end;
 {=====}
 
@@ -473,7 +473,7 @@ begin
   begin
     SendMessage(FlexEdit.Handle, EM_SETSEL, SelStart, SelStart +
       SendMessage(FlexEdit.Handle, EM_LINELENGTH, SelStart, 0));
-    SendMessage(FlexEdit.Handle, EM_REPLACESEL, 0, NativeInt(PChar(S)));
+    SendMessage(FlexEdit.Handle, EM_REPLACESEL, 0, lParam(PChar(S)));
   end;
 end;
 {=====}
@@ -498,7 +498,7 @@ begin
       Line := #13#10 + s;
     end;
     SendMessage(FlexEdit.Handle, EM_SETSEL, SelStart, SelStart);
-    SendMessage(FlexEdit.Handle, EM_REPLACESEL, 0, NativeInt(PChar(Line)));
+    SendMessage(FlexEdit.Handle, EM_REPLACESEL, 0, lParam(PChar(Line)));
   end;
 end;
 {=====}
@@ -516,7 +516,7 @@ begin
     if SelEnd < 0 then SelEnd := SelStart +
       SendMessage(FlexEdit.Handle, EM_LINELENGTH, SelStart, 0);
     SendMessage(FlexEdit.Handle, EM_SETSEL, SelStart, SelEnd);
-    SendMessage(FlexEdit.Handle, EM_REPLACESEL, 0, NativeInt(Empty));
+    SendMessage(FlexEdit.Handle, EM_REPLACESEL, 0, lParam(Empty));
   end;
 end;
 {=====}
@@ -1106,7 +1106,7 @@ begin
   cures this and does not seem to affect the operation in D6 or D7.
   TNX to John Cooper - neutronwrangler - for providing the fix.
 }
-      SendMessage(WindowHandle, WM_SETTEXT, 0, NativeInt(Params.Caption));
+      SendMessage(WindowHandle, WM_SETTEXT, 0, lParam(Params.Caption));
     end;
   end;
 end;

--- a/source/O32IGrid.pas
+++ b/source/O32IGrid.pas
@@ -182,7 +182,9 @@ type
     procedure DropDownList(Value: Boolean);
     function DoMouseWheel(Shift: TShiftState; WheelDelta: Integer;
       MousePos: TPoint): Boolean; override;
-    procedure WMMouseWheel(var Msg : TMessage); message WM_MOUSEWHEEL;
+    {DM - START CHANGE}
+    // removed procedure WMMouseWheel(var Msg : TMessage); message WM_MOUSEWHEEL;
+    {DM - END CHANGE}
     function  EditCanModify: Boolean;
     procedure KeyDown(var Key: Word; Shift: TShiftState); override;
     procedure KeyPress(var Key: Char); override;
@@ -220,7 +222,9 @@ type
     procedure DropDownList(Value: Boolean);
     function DoMouseWheel(Shift: TShiftState; WheelDelta: Integer;
       MousePos: TPoint): Boolean; override;
-    procedure WMMouseWheel(var Msg : TMessage); message WM_MOUSEWHEEL;
+    {DM - START CHANGE}
+    // removed procedure WMMouseWheel(var Msg : TMessage); message WM_MOUSEWHEEL;
+    {DM - END CHANGE}
     function  EditCanModify: Boolean;
     procedure KeyDown(var Key: Word; Shift: TShiftState); override;
     procedure KeyPress(var Key: Char); override;
@@ -586,7 +590,9 @@ type
     function DoMouseWheelUp(Shift: TShiftState; MousePos: TPoint): Boolean; override;
     procedure DoOnExpand(Index: Integer);
     procedure DoOnCollapse(Index: Integer);
-    procedure WMMouseWheel(var Msg : TMessage); message WM_MOUSEWHEEL;
+    {DM - START CHANGE}
+    // procedure WMMouseWheel(var Msg : TMessage); message WM_MOUSEWHEEL;
+    {DM - END CHANGE}
     function GetEditText(ACol, ARow: Integer): string; dynamic;
     procedure SetEditText(ACol, ARow: Integer; const Value: string); dynamic;
     function GetEditMask(ACol, ARow: Integer): string; dynamic;
@@ -1080,7 +1086,7 @@ procedure TO32GridEdit.KeyDown(var Key: Word; Shift: TShiftState);
 
   function Selection: TSelection;
   begin
-    SendMessage(Handle, EM_GETSEL, NativeInt(@Result.StartPos), NativeInt(@Result.EndPos));
+    SendMessage(Handle, EM_GETSEL, wParam(@Result.StartPos), lParam(@Result.EndPos));
   end;
 
   function RightSide: Boolean;
@@ -1144,7 +1150,7 @@ begin
     #9, #27: Key := #0;
     #13:
       begin
-        SendMessage(Handle, EM_GETSEL, NativeInt(@Selection.StartPos), NativeInt(@Selection.EndPos));
+        SendMessage(Handle, EM_GETSEL, wParam(@Selection.StartPos), lParam(@Selection.EndPos));
         if (Selection.StartPos = 0) and (Selection.EndPos = GetTextLen) then
           Deselect else
           SelectAll;
@@ -1184,7 +1190,7 @@ end;
 
 procedure TO32GridEdit.Deselect;
 begin
-  SendMessage(Handle, EM_SETSEL, $7FFFFFFF, NativeInt($FFFFFFFF));
+  SendMessage(Handle, EM_SETSEL, $7FFFFFFF, lParam($FFFFFFFF));
 end;
 {=====}
 
@@ -1254,7 +1260,7 @@ var
   R: TRect;
 begin
   R := Rect(2, 2, Width - 2, Height);
-  SendMessage(Handle, EM_SETRECTNP, 0, NativeInt(@R));
+  SendMessage(Handle, EM_SETRECTNP, 0, lParam(@R));
   SendMessage(Handle, EM_SCROLLCARET, 0, 0);
 end;
 {=====}
@@ -1330,7 +1336,7 @@ procedure TO32GridCombo.DropDownList(Value: Boolean);
 var
   R: TRect;
 begin
-  SendMessage(Handle, CB_SHOWDROPDOWN, NativeInt(Value), 0);
+  SendMessage(Handle, CB_SHOWDROPDOWN, wParam(Value), 0);
   R := ClientRect;
   InvalidateRect(Handle, @R, True);
 end;
@@ -1417,7 +1423,7 @@ procedure TO32GridCombo.KeyDown(var Key: Word; Shift: TShiftState);
 
   function Selection: TSelection;
   begin
-    SendMessage(Handle, EM_GETSEL, NativeInt(@Result.StartPos), NativeInt(@Result.EndPos));
+    SendMessage(Handle, EM_GETSEL, wParam(@Result.StartPos), lParam(@Result.EndPos));
   end;
 
   function RightSide: Boolean;
@@ -1477,7 +1483,7 @@ begin
     #9, #27: Key := #0;
     #13:
       begin
-        SendMessage(Handle, EM_GETSEL, NativeInt(@Selection.StartPos), NativeInt(@Selection.EndPos));
+        SendMessage(Handle, EM_GETSEL, wParam(@Selection.StartPos), lParam(@Selection.EndPos));
         if (Selection.StartPos = 0) and (Selection.EndPos = GetTextLen) then
           Deselect else
           SelectAll;
@@ -1519,7 +1525,7 @@ end;
 
 procedure TO32GridCombo.Deselect;
 begin
-  SendMessage(Handle, EM_SETSEL, $7FFFFFFF, NativeInt($FFFFFFFF));
+  SendMessage(Handle, EM_SETSEL, $7FFFFFFF, lParam($FFFFFFFF));
 end;
 {=====}
 
@@ -1567,7 +1573,7 @@ var
   R: TRect;
 begin
   R := Rect(2, 2, Width - 2, Height);
-  SendMessage(Handle, EM_SETRECTNP, 0, NativeInt(@R));
+  SendMessage(Handle, EM_SETRECTNP, 0, lParam(@R));
   SendMessage(Handle, EM_SCROLLCARET, 0, 0);
 end;
 {=====}
@@ -1634,7 +1640,7 @@ procedure TO32GridColorCombo.DropDownList(Value: Boolean);
 var
   R: TRect;
 begin
-  SendMessage(Handle, CB_SHOWDROPDOWN, NativeInt(Value), 0);
+  SendMessage(Handle, CB_SHOWDROPDOWN, wParam(Value), 0);
   R := ClientRect;
   InvalidateRect(Handle, @R, True);
 end;
@@ -1720,7 +1726,7 @@ procedure TO32GridColorCombo.KeyDown(var Key: Word; Shift: TShiftState);
 
   function Selection: TSelection;
   begin
-    SendMessage(Handle, EM_GETSEL, NativeInt(@Result.StartPos), NativeInt(@Result.EndPos));
+    SendMessage(Handle, EM_GETSEL, wParam(@Result.StartPos), lParam(@Result.EndPos));
   end;
 
   function RightSide: Boolean;
@@ -1780,7 +1786,7 @@ begin
     #9, #27: Key := #0;
     #13:
       begin
-        SendMessage(Handle, EM_GETSEL, NativeInt(@Selection.StartPos), NativeInt(@Selection.EndPos));
+        SendMessage(Handle, EM_GETSEL, wParam(@Selection.StartPos), lParam(@Selection.EndPos));
         if (Selection.StartPos = 0) and (Selection.EndPos = GetTextLen) then
           Deselect else
           SelectAll;
@@ -1820,23 +1826,14 @@ begin
 end;
 {=====}
 
-procedure TO32GridColorCombo.WMMouseWheel(var Msg : TMessage);
-var
-  Delta: integer;
-begin
-  Delta := TWMMouseWheel(Msg).WheelDelta;
-   if Delta < 0 then begin
-     if (FGrid.ActiveRow < FGrid.RowCount - 1) then
-       FGrid.FocusCell(1, FGrid.ActiveRow + 1, true);
-   end
-   else if (FGrid.ActiveRow > 0) then
-     FGrid.FocusCell(1, FGrid.ActiveRow - 1, true);
-end;
+{DM - START CHANGE}
+// removed procedure TO32GridColorCombo.WMMouseWheel(var Msg : TMessage);
+{DM - END CHANGE}
 {=====}
 
 procedure TO32GridColorCombo.Deselect;
 begin
-  SendMessage(Handle, EM_SETSEL, $7FFFFFFF, NativeInt($FFFFFFFF));
+  SendMessage(Handle, EM_SETSEL, $7FFFFFFF, lParam($FFFFFFFF));
 end;
 {=====}
 
@@ -1884,7 +1881,7 @@ var
   R: TRect;
 begin
   R := Rect(2, 2, Width - 2, Height);
-  SendMessage(Handle, EM_SETRECTNP, 0, NativeInt(@R));
+  SendMessage(Handle, EM_SETRECTNP, 0, lParam(@R));
   SendMessage(Handle, EM_SCROLLCARET, 0, 0);
 end;
 {=====}
@@ -1956,7 +1953,7 @@ procedure TO32GridFontCombo.DropDownList(Value: Boolean);
 var
   R: TRect;
 begin
-  SendMessage(Handle, CB_SHOWDROPDOWN, NativeInt(Value), 0);
+  SendMessage(Handle, CB_SHOWDROPDOWN, wParam(Value), 0);
   R := ClientRect;
   InvalidateRect(Handle, @R, True);
 end;
@@ -2042,7 +2039,7 @@ procedure TO32GridFontCombo.KeyDown(var Key: Word; Shift: TShiftState);
 
   function Selection: TSelection;
   begin
-    SendMessage(Handle, EM_GETSEL, NativeInt(@Result.StartPos), NativeInt(@Result.EndPos));
+    SendMessage(Handle, EM_GETSEL, wParam(@Result.StartPos), lParam(@Result.EndPos));
   end;
 
   function RightSide: Boolean;
@@ -2102,7 +2099,7 @@ begin
     #9, #27: Key := #0;
     #13:
       begin
-        SendMessage(Handle, EM_GETSEL, NativeInt(@Selection.StartPos), NativeInt(@Selection.EndPos));
+        SendMessage(Handle, EM_GETSEL, wParam(@Selection.StartPos), lParam(@Selection.EndPos));
         if (Selection.StartPos = 0) and (Selection.EndPos = GetTextLen) then
           Deselect else
           SelectAll;
@@ -2142,23 +2139,14 @@ begin
 end;
 {=====}
 
-procedure TO32GridFontCombo.WMMouseWheel(var Msg : TMessage);
-var
-  Delta: integer;
-begin
-  Delta := TWMMouseWheel(Msg).WheelDelta;
-   if Delta < 0 then begin
-     if (FGrid.ActiveRow < FGrid.RowCount - 1) then
-       FGrid.FocusCell(1, FGrid.ActiveRow + 1, true);
-   end
-   else if (FGrid.ActiveRow > 0) then
-     FGrid.FocusCell(1, FGrid.ActiveRow - 1, true);
-end;
+{DM - START CHANGE}
+// removed procedure TO32GridFontCombo.WMMouseWheel(var Msg : TMessage);
+{DM - END CHANGE}
 {=====}
 
 procedure TO32GridFontCombo.Deselect;
 begin
-  SendMessage(Handle, EM_SETSEL, $7FFFFFFF, NativeInt($FFFFFFFF));
+  SendMessage(Handle, EM_SETSEL, $7FFFFFFF, lParam($FFFFFFFF));
 end;
 {=====}
 
@@ -2209,7 +2197,7 @@ var
   R: TRect;
 begin
   R := Rect(2, 2, Width - 2, Height);
-  SendMessage(Handle, EM_SETRECTNP, 0, NativeInt(@R));
+  SendMessage(Handle, EM_SETRECTNP, 0, lParam(@R));
   SendMessage(Handle, EM_SCROLLCARET, 0, 0);
 end;
 {=====}
@@ -6046,7 +6034,7 @@ end;
 
 procedure TO32CustomInspectorGrid.CMDesignHitTest(var Msg: TCMDesignHitTest);
 begin
-  Msg.Result := NativeInt(BOOL(Sizing(Msg.Pos.X, Msg.Pos.Y)));
+  Msg.Result := lResult(BOOL(Sizing(Msg.Pos.X, Msg.Pos.Y)));
 end;
 {=====}
 
@@ -6172,18 +6160,9 @@ begin
 end;
 {=====}
 
-procedure TO32CustomInspectorGrid.WMMouseWheel(var Msg : TMessage);
-var
-  Delta: integer;
-begin
-  Delta := TWMMouseWheel(Msg).WheelDelta;
-   if Delta < 0 then begin
-     if (ActiveRow < RowCount - 1) then
-       FocusCell(1, ActiveRow + 1, true);
-   end
-   else if (ActiveRow > 0) then
-     FocusCell(1, ActiveRow - 1, true);
-end;
+{DM - START CHANGE}
+// removed procedure TO32CustomInspectorGrid.WMMouseWheel(var Msg : TMessage);
+{DM - END CHANGE}
 {=====}
 
 function TO32CustomInspectorGrid.CheckColumnDrag(var Origin,

--- a/source/O32LkOut.pas
+++ b/source/O32LkOut.pas
@@ -1139,7 +1139,7 @@ end;
 
 procedure TO32CustomLookOutBar.CMDesignHitTest(var Msg : TCMDesignHitTest);
 begin
-  Msg.Result := Integer(lobOverButton);
+  Msg.Result := lResult(lobOverButton);
 end;
 {=====}
 
@@ -1163,7 +1163,7 @@ begin
   inherited CreateParams(Params);
 
   with Params do
-    Style := Integer(Style) or BorderStyles[FBorderStyle];
+    Style := DWORD(Style) or BorderStyles[FBorderStyle];
 
   if NewStyleControls and Ctl3D and (FBorderStyle = bsSingle) then begin
     Params.Style := Params.Style and not WS_BORDER;
@@ -1450,7 +1450,7 @@ function GetLargeIconDisplayName(Canvas : TCanvas;
 var
   TestRect : TRect;
   SH, DH : Integer;
-  Buf : array[0..255] of Char;
+  //Buf : array[0..255] of Char;
   I : Integer;
   TempName : string;
   Temp2 : string;
@@ -1463,8 +1463,7 @@ begin
     Right := 1;
     Bottom := 1;
   end;
-  SH := DrawText(Canvas.Handle, 'W W', 3, TestRect,
-    DT_SINGLELINE or DT_CALCRECT);
+  SH := DrawText(Canvas.Handle, 'W W', 3, TestRect, DT_SINGLELINE or DT_CALCRECT);
 
   {get double line height}
   with TestRect do begin
@@ -1473,14 +1472,12 @@ begin
     Right := 1;
     Bottom := 1;
   end;
-  DH := DrawText(Canvas.Handle, 'W W', 3, TestRect,
-    DT_WORDBREAK or DT_CALCRECT);
+  DH := DrawText(Canvas.Handle, 'W W', 3, TestRect, DT_WORDBREAK or DT_CALCRECT);
 
   {see if the text can fit within the existing rect without growing}
   TestRect := Rect;
-  StrPLCopy(Buf, TempName, 255);
-  DrawText(Canvas.Handle, Buf, Length(TempName), TestRect,
-            DT_WORDBREAK or DT_CALCRECT);
+  //StrPLCopy(Buf, TempName, 255);
+  DrawText(Canvas.Handle, PChar(TempName), Length(TempName), TestRect, DT_WORDBREAK or DT_CALCRECT);
   I := Pos(' ', TempName);
   if (RectHeight(TestRect) = SH) or (I < 2) then
     Result := GetDisplayString(Canvas, TempName, 1, RectWidth(Rect))
@@ -1490,47 +1487,38 @@ begin
     Temp2 := GetDisplayString(Canvas, Copy(TempName, 1, I-1), 1,
                               RectWidth(Rect));
     if CompareStr(Temp2, Copy(TempName, 1, I-1)) <> 0 then begin
-      Result := GetDisplayString(Canvas, Copy(TempName, 1, I-1), 1,
-                                 RectWidth(Rect)) +
+      Result := GetDisplayString(Canvas, Copy(TempName, 1, I-1), 1, RectWidth(Rect)) +
                 ' ' +
-                GetDisplayString(Canvas, Copy(TempName, I+1,
-                                 Length(TempName) - I), 1, RectWidth(Rect));
+                GetDisplayString(Canvas, Copy(TempName, I+1, Length(TempName) - I), 1, RectWidth(Rect));
     end else begin
       {2 or more lines, and the first line isn't getting an ellipsis}
-      if (RectHeight(TestRect) = DH) and
-         (RectWidth(TestRect) <= RectWidth(Rect)) then
+      if (RectHeight(TestRect) = DH) and (RectWidth(TestRect) <= RectWidth(Rect)) then
         {it will fit}
         Result := TempName
       else begin
         {it won't fit, but the first line wraps OK - 2nd line needs an ellipsis}
         TestRect.Right := Rect.Right + 1;
-        while (RectWidth(TestRect) > RectWidth(Rect)) or
-              (RectHeight(TestRect) > DH) do begin
+        while (RectWidth(TestRect) > RectWidth(Rect)) or (RectHeight(TestRect) > DH) do
+        begin
           if Length(TempName) > 1 then begin
             TestRect := Rect;
             Delete(TempName, Length(TempName), 1);
             TempName := Trim(TempName);
-            StrPLCopy(Buf, TempName + '...', 255);
-            DrawText(Canvas.Handle, Buf, Length(TempName) + 3, TestRect,
-              DT_WORDBREAK or DT_CALCRECT);
-            Result := TempName + '...';
+            Result := TempName + EllipsisStr;
+            DrawText(Canvas.Handle, PChar(Result), Length(Result), TestRect, DT_WORDBREAK or DT_CALCRECT);
           end else begin
-            Result := TempName + '..';
+            Result := TempName + Copy(EllipsisStr, 1, 2);
             TestRect := Rect;
-            StrPLCopy(Buf, Result, 255);
-            DrawText(Canvas.Handle, Buf, Length(Result), TestRect,
-                      DT_WORDBREAK or DT_CALCRECT);
-            if (RectWidth(TestRect) <= RectWidth(Rect)) and
-              (RectHeight(TestRect) > DH) then
-                Break;
-            Result := TempName + '.';
+            //StrPLCopy(Buf, Result, 255);
+            DrawText(Canvas.Handle, PChar(Result), Length(Result), TestRect, DT_WORDBREAK or DT_CALCRECT);
+            if (RectWidth(TestRect) <= RectWidth(Rect)) and (RectHeight(TestRect) > DH) then
+              Break;
+            Result := TempName + Copy(EllipsisStr, 1, 1);
             TestRect := Rect;
-            StrPLCopy(Buf, Result, 255);
-            DrawText(Canvas.Handle, Buf, Length(Result), TestRect,
-                      DT_WORDBREAK or DT_CALCRECT);
-            if (RectWidth(TestRect) <= RectWidth(Rect)) and
-              (RectHeight(TestRect) > DH) then
-                Break;
+            //StrPLCopy(Buf, Result, 255);
+            DrawText(Canvas.Handle, PChar(result), Length(Result), TestRect, DT_WORDBREAK or DT_CALCRECT);
+            if (RectWidth(TestRect) <= RectWidth(Rect)) and (RectHeight(TestRect) > DH) then
+              Break;
             Result := TempName;
           end;
         end;

--- a/source/OvcBase.pas
+++ b/source/OvcBase.pas
@@ -123,8 +123,9 @@ type
   end;
 
   {event method types}
-  TMouseWheelEvent = procedure(Sender : TObject; Shift : TShiftState;
-                                Delta, XPos, YPos : Word) of object;
+  {DM - START CHANGE}
+  // removed TMouseWheelEvent
+  {DM - END CHANGE}
 
   TDataErrorEvent =
     procedure(Sender : TObject; ErrorCode : Word; const ErrorMsg : string)
@@ -348,7 +349,9 @@ type
     {property variables}
     FAfterEnter         : TNotifyEvent;
     FAfterExit          : TNotifyEvent;
-    FOnMouseWheel       : TMouseWheelEvent;
+    {DM - START CHANGE}
+    // removed FOnMouseWheel       : TMouseWheelEvent;
+    {DM - END CHANGE}
     FLabelInfo          : TOvcLabelInfo;
     FInternal : Boolean; {flag to suppress name generation
                           on collection items}
@@ -382,17 +385,17 @@ type
     {windows message methods}
     procedure WMKillFocus(var Msg : TWMKillFocus);
       message WM_KILLFOCUS;
-    procedure WMMouseWheel(var Msg : TMessage);
-      message WM_MOUSEWHEEL;
+    {DM - START CHANGE}
+    // removed procedure WMMouseWheel
+    {DM - END CHANGE}
     procedure WMSetFocus(var Msg : TWMSetFocus);
       message WM_SETFOCUS;
 
   protected
     DefaultLabelPosition : TOvcLabelPosition;
-
-    procedure DoOnMouseWheel(Shift : TShiftState;
-                             Delta, XPos, YPos : SmallInt);
-      dynamic;
+    {DM - START CHANGE}
+    // removed procedure DoOnMouseWheel
+    {DM - END CHANGE}
     procedure CreateWnd;
       override;
     procedure Notification(AComponent : TComponent; Operation : TOperation);
@@ -402,8 +405,9 @@ type
       read FAfterEnter write FAfterEnter;
     property AfterExit : TNotifyEvent
       read FAfterExit write FAfterExit;
-    property OnMouseWheel : TMouseWheelEvent
-      read FOnMouseWheel write FOnMouseWheel;
+    {DM - START CHANGE}
+    // removed property OnMouseWheel
+    {DM - END CHANGE}
     property LabelInfo : TOvcLabelInfo
       read FLabelInfo write FLabelInfo;
 
@@ -421,6 +425,8 @@ type
   published
     property About : string
       read GetAbout write SetAbout stored False;
+
+    property Touch;
   end;
   {End - TO32CustomControl}
 
@@ -431,7 +437,9 @@ type
     FAfterEnter         : TNotifyEvent;
     FAfterExit          : TNotifyEvent;
     FCollectionStreamer : TOvcCollectionStreamer;
-    FOnMouseWheel       : TMouseWheelEvent;
+    {DM - START CHANGE}
+    // removed FOnMouseWheel       : TMouseWheelEvent;
+    {DM - END CHANGE}
     FLabelInfo          : TOvcLabelInfo;
     FInternal : Boolean; {flag to suppress name generation
                           on collection items}
@@ -465,8 +473,9 @@ type
     {windows message methods}
     procedure WMKillFocus(var Msg : TWMKillFocus);
       message WM_KILLFOCUS;
-    procedure WMMouseWheel(var Msg : TMessage);
-      message WM_MOUSEWHEEL;
+    {DM - START CHANGE}
+    // removed procedure WMMouseWheel
+    {DM - END CHANGE}
     procedure WMSetFocus(var Msg : TWMSetFocus);
       message WM_SETFOCUS;
 
@@ -477,10 +486,9 @@ type
     {the top left of the control. if dlpBottomLeft, the default location and}
     {POR will be at the bottom left}
     DefaultLabelPosition : TOvcLabelPosition;
-
-    procedure DoOnMouseWheel(Shift : TShiftState;
-                             Delta, XPos, YPos : SmallInt);
-      dynamic;
+    {DM - START CHANGE}
+    // removed function DoOnMouseWheel
+    {DM - END CHANGE}
     procedure CreateWnd;
       override;
     procedure Notification(AComponent : TComponent; Operation : TOperation);
@@ -493,8 +501,9 @@ type
       read FAfterEnter write FAfterEnter;
     property AfterExit : TNotifyEvent
       read FAfterExit write FAfterExit;
-    property OnMouseWheel : TMouseWheelEvent
-      read FOnMouseWheel write FOnMouseWheel;
+    {DM - START CHANGE}
+    // removed property OnMouseWheel
+    {DM - END CHANGE}
     property LabelInfo : TOvcLabelInfo
       read FLabelInfo write FLabelInfo;
 
@@ -954,7 +963,7 @@ begin
   if Assigned(PF) then begin
     for I := 0 to Pred(PF.ComponentCount) do begin
       if PF.Components[I] = FControl then begin
-        SendMessage(FControl.Handle, OM_ASSIGNLABEL, 0, NativeInt(Self));
+        SendMessage(FControl.Handle, OM_ASSIGNLABEL, 0, lParam(Self));
         PostMessage(FControl.Handle, OM_RECORDLABELPOSITION, 0, 0);
         Break;
       end;
@@ -1464,7 +1473,7 @@ end;
 procedure TOvcController.DelayNotify(Sender : TObject; NotifyCode : Word);
 begin
   if Assigned(FOnDelayNotify) then
-    PostMessage(Handle, OM_DELAYNOTIFY, NotifyCode, NativeInt(Sender));
+    PostMessage(Handle, OM_DELAYNOTIFY, NotifyCode, lParam(Sender));
 end;
 
 destructor TOvcController.Destroy;
@@ -1508,7 +1517,7 @@ begin
   else
     H := 0;
 
-  PostMessage(Handle, OM_POSTEDIT, H, NativeInt(Sender));
+  PostMessage(Handle, OM_POSTEDIT, H, lParam(Sender));
 end;
 
 procedure TOvcController.DoOnPreEdit(Sender : TObject; LosingControl : TWinControl);
@@ -1520,7 +1529,7 @@ begin
   else
     H := 0;
 
-  PostMessage(Handle, OM_PREEDIT, H, NativeInt(Sender));
+  PostMessage(Handle, OM_PREEDIT, H, lParam(Sender));
 end;
 
 procedure TOvcController.DoOnTimerTrigger(Sender : TObject; Handle : Integer;
@@ -1619,7 +1628,7 @@ var
 
         {ask the controller to give the focus back to this field}
         if ChangeFocus and not ErrorPending then begin
-          PostMessage(Handle, OM_SETFOCUS, 0, NativeInt(EF));
+          PostMessage(Handle, OM_SETFOCUS, 0, lParam(EF));
           ErrorPending := True;
         end;
 
@@ -1675,7 +1684,7 @@ begin
 
         {ask the controller to give the focus back to this field}
         if not ErrorPending then begin
-          PostMessage(Handle, OM_SETFOCUS, 0, NativeInt(EF));
+          PostMessage(Handle, OM_SETFOCUS, 0, lParam(EF));
           ErrorPending := True;
         end;
 
@@ -1774,12 +1783,9 @@ begin
   inherited Destroy;
 end;
 
-procedure TO32CustomControl.DoOnMouseWheel(Shift : TShiftState;
-                                 Delta, XPos, YPos : SmallInt);
-begin
-  if Assigned(FOnMouseWheel) then
-    FOnMouseWheel(Self, Shift, Delta, XPos, YPos);
-end;
+{DM - START CHANGE}
+// removed function TO32CustomControl.DoOnMouseWheel
+{DM - END CHANGE}
 
 function TO32CustomControl.GetAttachedLabel : TOvcAttachedLabel;
 begin
@@ -1941,13 +1947,9 @@ begin
   PostMessage(Handle, OM_AFTEREXIT, 0, 0);
 end;
 
-procedure TO32CustomControl.WMMouseWheel(var Msg : TMessage);
-begin
-  with Msg do
-    DoOnMouseWheel(KeysToShiftState(LOWORD(wParam)) {fwKeys},
-                   HIWORD(wParam) {zDelta},
-                   LOWORD(lParam) {xPos},   HIWORD(lParam) {yPos});
-end;
+{DM - START CHANGE}
+// removed procedure TO32CustomControl.WMMouseWheel
+{DM - END CHANGE}
 
 procedure TO32CustomControl.WMSetFocus(var Msg : TWMSetFocus);
 begin
@@ -1997,12 +1999,9 @@ begin
   inherited Destroy;
 end;
 
-procedure TOvcCustomControl.DoOnMouseWheel(Shift : TShiftState;
-                                 Delta, XPos, YPos : SmallInt);
-begin
-  if Assigned(FOnMouseWheel) then
-    FOnMouseWheel(Self, Shift, Delta, XPos, YPos);
-end;
+{DM - START CHANGE}
+// removed function TOvcCustomControl.DoOnMouseWheel
+{DM - END CHANGE}
 
 function TOvcCustomControl.GetAttachedLabel : TOvcAttachedLabel;
 begin
@@ -2164,13 +2163,9 @@ begin
   PostMessage(Handle, OM_AFTEREXIT, 0, 0);
 end;
 
-procedure TOvcCustomControl.WMMouseWheel(var Msg : TMessage);
-begin
-  with Msg do
-    DoOnMouseWheel(KeysToShiftState(LOWORD(wParam)) {fwKeys},
-                   HIWORD(wParam) {zDelta},
-                   LOWORD(lParam) {xPos},   HIWORD(lParam) {yPos});
-end;
+{DM - START CHANGE}
+// removed procedure TOvcCustomControl.WMMouseWheel
+{DM - END CHANGE}
 
 procedure TOvcCustomControl.WMSetFocus(var Msg : TWMSetFocus);
 begin

--- a/source/OvcCalc.pas
+++ b/source/OvcCalc.pas
@@ -2301,12 +2301,12 @@ end;
 
 procedure TOvcCustomCalculator.CreateParams(var Params : TCreateParams);
 const
-  BorderStyles : array[TBorderStyle] of Integer = (0, WS_BORDER);
+  BorderStyles : array[TBorderStyle] of DWORD = (0, WS_BORDER);
 begin
   inherited CreateParams(Params);
 
   with Params do begin
-    Style := Integer(Style) or BorderStyles[FBorderStyle];
+    Style := DWORD(Style) or BorderStyles[FBorderStyle];
     if cPopup then begin
       Style := WS_POPUP or WS_BORDER;
       WindowClass.Style := WindowClass.Style or CS_SAVEBITS;

--- a/source/OvcCoco.pas
+++ b/source/OvcCoco.pas
@@ -522,7 +522,8 @@ begin
   inc(pos, SizeOf(Char));
   while not CharInSet(ch, LineEnds) do
   begin
-    SetLength(line, length(Line) + 1);
+    if Length(line) < i then
+      SetLength(line, i + 20);
     line[i] := ch;
     inc(i);
     ch := Scanner.CharAt(pos);

--- a/source/OvcData.pas
+++ b/source/OvcData.pas
@@ -46,9 +46,9 @@ uses
   OvcDate, O32SR;
 
 const
-  BorderStyles    : array[TBorderStyle] of Integer =
+  BorderStyles    : array[TBorderStyle] of DWORD =
                     (0, WS_BORDER);
-  ScrollBarStyles : array [UITypes.TScrollStyle] of Integer =
+  ScrollBarStyles : array [UITypes.TScrollStyle] of DWORD =
                     (0, WS_HSCROLL, WS_VSCROLL, WS_HSCROLL or WS_VSCROLL);
 
 {some colors that are not defined by Delphi}
@@ -259,15 +259,15 @@ type
   PRangeType = ^TRangeType;
   TRangeType = packed record
     case Byte of                         {size}
-    00 : (rtChar : Char);             {01/02}
+    00 : (rtChar : Char);                 {01/02}
     01 : (rtByte : Byte);                 {01}
     02 : (rtSht  : ShortInt);             {01}
     03 : (rtInt  : SmallInt);             {02}
     04 : (rtWord : Word);                 {02}
-    05 : (rtLong : NativeInt);            {04}
+    05 : (rtLong : Integer);              {04}
     06 : (rtSgl  : Single);               {04}
     07 : (rtPtr  : Pointer);              {04}
-     08 : (rtReal : Real);                 {06}
+    08 : (rtReal : Real);                 {06}
     09 : (rtDbl  : Double);               {08}
     10 : (rtComp : Comp);                 {08}
     11 : (rtExt  : Extended);             {10}
@@ -419,22 +419,22 @@ type
     Msg    : Cardinal;
     Error  : Word;
     Unused : Word;
-    lParam : Integer;
-    Result : Integer;
+    lParam : LParam;
+    Result : LRESULT;
   end;
 
   TOMSetFocus = packed record
     Msg    : Cardinal;
-    wParam : Integer;
+    wParam : WParam;
     Control: TWinControl;
-    Result : Integer;
+    Result : LRESULT;
   end;
 
   TOMShowStatus = packed record
     Msg    : Cardinal;
     Column : Integer;
     Line   : Integer;
-    Result : Integer;
+    Result : LRESULT;
   end;
 
 

--- a/source/OvcDate.pas
+++ b/source/OvcDate.pas
@@ -56,7 +56,7 @@ type
     {In STDATE, dates are stored in long integer format as the number of days
     since January 1, 1600}
 
-  TDateArray = array[0..(MaxLongInt div SizeOf(TStDate))-1] of TStDate;
+  TDateArray = array[0..(MaxInt div SizeOf(TStDate))-1] of TStDate;
     {Type for StDate open array}
 
   TStDayType = (Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday);
@@ -410,7 +410,7 @@ var
   GC   : Boolean;
 
 begin
-  Result := -MaxLongInt;
+  Result := -MaxInt;
   if (not (Month in [1..12])) or (Date < 1)  then
     Exit
   else if (Month in [1, 3, 5, 7, 8, 10, 12]) and (Date > 31) then

--- a/source/OvcEdClc.pas
+++ b/source/OvcEdClc.pas
@@ -406,7 +406,7 @@ begin
       begin
         if Shift = [ssShift] then begin
           PopupClose(Sender);
-          PostMessage(Handle, WM_KeyDown, VK_TAB, Integer(ssShift));
+          PostMessage(Handle, WM_KeyDown, VK_TAB, LParam(ssShift));
         end else if Shift = [] then begin
           PopupClose(Sender);
           PostMessage(Handle, WM_KeyDown, VK_TAB, 0);

--- a/source/OvcIntl.pas
+++ b/source/OvcIntl.pas
@@ -1340,7 +1340,7 @@ var
     {copy substring into Dest, replace substring with SubChar}
     L := 0;
     while wLongDate[I] <> '''' do
-      if L < SizeOf(wldSub1) then begin
+      if L < Length(wldSub1) then begin
         Dest[L] := wLongDate[I];
         Inc(L);
         wLongDate[I] := SubChar;

--- a/source/OvcLkOut.pas
+++ b/source/OvcLkOut.pas
@@ -733,7 +733,7 @@ end;
 
 procedure TOvcLookOutBar.CMDesignHitTest(var Msg : TCMDesignHitTest);
 begin
-  Msg.Result := Integer(lobOverButton);
+  Msg.Result := lResult(lobOverButton);
 end;
 
 procedure TOvcLookOutBar.CMFontChanged(var Message: TMessage);
@@ -858,7 +858,7 @@ begin
   inherited CreateParams(Params);
 
   with Params do
-    Style := Integer(Style) or BorderStyles[FBorderStyle];
+    Style := DWORD(Style) or BorderStyles[FBorderStyle];
 
   if NewStyleControls and Ctl3D and (FBorderStyle = bsSingle) then begin
     Params.Style := Params.Style and not WS_BORDER;
@@ -1047,8 +1047,7 @@ begin
 
   {see if the text can fit within the existing rect without growing}
   TestRect := Rect;
-  DrawText(Canvas.Handle, PChar(TempName), Length(TempName), TestRect,
-            DT_WORDBREAK or DT_CALCRECT);
+  DrawText(Canvas.Handle, PChar(TempName), Length(TempName), TestRect, DT_WORDBREAK or DT_CALCRECT);
   I := Pos(' ', TempName);
   if (HeightOf(TestRect) = SH) or (I < 2) then
     Result := GetDisplayString(Canvas, TempName, 1, WidthOf(Rect))
@@ -1058,43 +1057,36 @@ begin
     Temp2 := GetDisplayString(Canvas, Copy(TempName, 1, I-1), 1,
                               WidthOf(Rect));
     if CompareStr(Temp2, Copy(TempName, 1, I-1)) <> 0 then begin
-      Result := GetDisplayString(Canvas, Copy(TempName, 1, I-1), 1,
-                                 WidthOf(Rect)) +
+      Result := GetDisplayString(Canvas, Copy(TempName, 1, I-1), 1, WidthOf(Rect)) +
                 ' ' +
-                GetDisplayString(Canvas, Copy(TempName, I+1,
-                                 Length(TempName) - I), 1, WidthOf(Rect));
+                GetDisplayString(Canvas, Copy(TempName, I+1, Length(TempName) - I), 1, WidthOf(Rect));
     end else begin
       {2 or more lines, and the first line isn't getting an ellipsis}
-      if (HeightOf(TestRect) = DH) and
-         (WidthOf(TestRect) <= WidthOf(Rect)) then
+      if (HeightOf(TestRect) = DH) and (WidthOf(TestRect) <= WidthOf(Rect)) then
         {it will fit}
         Result := TempName
       else begin
         {it won't fit, but the first line wraps OK - 2nd line needs an ellipsis}
         TestRect.Right := Rect.Right + 1;
-        while (WidthOf(TestRect) > WidthOf(Rect)) or
-              (HeightOf(TestRect) > DH) do begin
+        while (WidthOf(TestRect) > WidthOf(Rect)) or (HeightOf(TestRect) > DH) do
+        begin
           if Length(TempName) > 1 then begin
             TestRect := Rect;
             Delete(TempName, Length(TempName), 1);
             TempName := Trim(TempName);
-            DrawText(Canvas.Handle, PChar(TempName + '...'), Length(TempName) + 3, TestRect, DT_WORDBREAK or DT_CALCRECT);
-            Result := TempName + '...';
+            Result := TempName + EllipsisStr;
+            DrawText(Canvas.Handle, PChar(Result), Length(Result), TestRect, DT_WORDBREAK or DT_CALCRECT);
           end else begin
-            Result := TempName + '..';
+            Result := TempName + Copy(EllipsisStr, 1, 2);
             TestRect := Rect;
-            DrawText(Canvas.Handle, PChar(Result){Buf}, Length(Result), TestRect,
-                      DT_WORDBREAK or DT_CALCRECT);
-            if (WidthOf(TestRect) <= WidthOf(Rect)) and
-              (HeightOf(TestRect) > DH) then
-                Break;
-            Result := TempName + '.';
+            DrawText(Canvas.Handle, PChar(Result){Buf}, Length(Result), TestRect, DT_WORDBREAK or DT_CALCRECT);
+            if (WidthOf(TestRect) <= WidthOf(Rect)) and (HeightOf(TestRect) > DH) then
+              Break;
+            Result := TempName + Copy(EllipsisStr, 1, 1);
             TestRect := Rect;
-            DrawText(Canvas.Handle, PChar(Result){Buf}, Length(Result), TestRect,
-                      DT_WORDBREAK or DT_CALCRECT);
-            if (WidthOf(TestRect) <= WidthOf(Rect)) and
-              (HeightOf(TestRect) > DH) then
-                Break;
+            DrawText(Canvas.Handle, PChar(Result){Buf}, Length(Result), TestRect, DT_WORDBREAK or DT_CALCRECT);
+            if (WidthOf(TestRect) <= WidthOf(Rect)) and (HeightOf(TestRect) > DH) then
+              Break;
             Result := TempName;
           end;
         end;

--- a/source/OvcMisc.pas
+++ b/source/OvcMisc.pas
@@ -145,6 +145,9 @@ procedure DebugOutput(const S : string);
 function GetArrowWidth(Width, Height : Integer) : Integer; register;
   {-Get arrow width for spinner-buttons}
 
+var
+  EllipsisStr: string = '...';
+
 implementation
 
 uses
@@ -288,7 +291,7 @@ end;
 procedure GetRGB(Clr : TColor; var IR, IG, IB : Byte);
 begin
   if (Clr < 0) then begin
-    Clr := Clr + MaxLongInt + 1;
+    Clr := Clr + MaxInt + 1;
     Clr := GetSysColor(Clr);
   end;
   IR := GetRValue(Clr);
@@ -564,7 +567,7 @@ var
   ShowEllipsis : Boolean;
 begin
   {be sure that the Canvas Font is set before entering this routine}
-  EllipsisWidth := Canvas.TextWidth('...');
+  EllipsisWidth := Canvas.TextWidth(EllipsisStr);
   Len := Length(S);
   Result := S;
   Extent := Canvas.TextWidth(Result);
@@ -581,10 +584,10 @@ begin
     Extent := Canvas.TextWidth(Result);
   end;
   if ShowEllipsis then begin
-    Result := Result + '...';
-    inc(Len, 3);
+    Result := Result + EllipsisStr;
+    iDots := Length(EllipsisStr);
+    inc(Len, iDots);
     Extent := Canvas.TextWidth(Result);
-    iDots := 3;
     while (iDots > 0) and (Extent > MaxWidth) do begin
       Delete(Result, Len, 1);
       Dec(Len);

--- a/source/OvcRvExpDef.pas
+++ b/source/OvcRvExpDef.pas
@@ -116,9 +116,9 @@ type
     procedure MatchType(ExpectedType: TOvcDRDataType);
   public
     procedure Assign(const Source: TOvcRvExpNode); override;
+    function AsBoolean(const ATestValue: Variant): Boolean;
     property UnaryNot: Boolean read FUnaryNot write FUnaryNot;
     property IsOp : TOvcRvExpIsOp read FIsOp write FIsOp;
-    function AsBoolean(const TestValue: Variant): Boolean;
   end;
 
   TOvcRvExpBetweenClause = class(TOvcRvExpNode)
@@ -2163,24 +2163,22 @@ end;
 
 { TOvcRvExpIsTest }
 
-function TOvcRvExpIsTest.AsBoolean(const TestValue: Variant): Boolean;
+function TOvcRvExpIsTest.AsBoolean(const ATestValue: Variant): Boolean;
 begin
   case IsOp of
-  ioNull :
-    Result := VarIsNull(TestValue) xor UnaryNot;
-  ioTrue :
-    if UnaryNot then
-      Result := not TestValue
+    ioNull :
+      Result := VarIsNull(ATestValue) xor FUnaryNot;
+    ioTrue : begin
+      Result := ATestValue;
+      if FUnaryNot then Result := not Result;
+    end;
+    ioFalse : begin
+      Result := not ATestValue;
+      if FUnaryNot then Result := not Result;
+    end;
     else
-      Result := TestValue;
-  ioFalse :
-    if UnaryNot then
-      Result := TestValue
-    else
-      Result := not TestValue;
-  else
-  //ioUnknown :
-    Result := VarIsNull(TestValue) xor UnaryNot;
+    //ioUnknown :
+      Result := VarIsNull(ATestValue) xor FUnaryNot;
   end;
 end;
 

--- a/source/OvcTimer.pas
+++ b/source/OvcTimer.pas
@@ -321,8 +321,8 @@ begin
         ER^.erLastTrigger := TC;
 
         {check if total elapsed time for trigger >= MaxLongInt}
-        if ((MaxLongInt - ER^.erElapsed) < ET) then
-          ER^.erElapsed := MaxLongInt
+        if ((MaxInt - ER^.erElapsed) < ET) then
+          ER^.erElapsed := MaxInt
         else
           ER^.erElapsed := ER^.erElapsed + ET;
 
@@ -554,7 +554,7 @@ begin
       {is this interval greater than the remaining time on any existing triggers}
       TR := 0;
       if (TC < ER^.erLastTrigger) then
-        TR := TR + MaxLongInt
+        TR := TR + MaxInt
       else
         TR := TC - ER^.erLastTrigger;
       if Integer(tpInterval) > (Integer(ER^.erInterval) - TR) then

--- a/source/OvcViewEd.dfm
+++ b/source/OvcViewEd.dfm
@@ -27,6 +27,7 @@ object frmViewEd: TfrmViewEd
     BorderStyle = sbsSunken
     Caption = ' Unused Fields:'
     TabOrder = 0
+    ExplicitWidth = 77
   end
   object Panel1: TScrollBox
     Left = 0
@@ -81,6 +82,7 @@ object frmViewEd: TfrmViewEd
     BorderStyle = sbsSunken
     Caption = ' Grouping:'
     TabOrder = 4
+    ExplicitWidth = 54
   end
   object StaticText3: TStaticText
     Left = 0
@@ -91,6 +93,7 @@ object frmViewEd: TfrmViewEd
     BorderStyle = sbsSunken
     Caption = ' Columns:'
     TabOrder = 5
+    ExplicitWidth = 51
   end
   object Button1: TButton
     Left = 344
@@ -173,6 +176,7 @@ object frmViewEd: TfrmViewEd
     BorderStyle = sbsSunken
     Caption = ' Filter expression:'
     TabOrder = 10
+    ExplicitWidth = 90
   end
   object Panel6: TPanel
     Left = 0

--- a/source/OvcViewEd.pas
+++ b/source/OvcViewEd.pas
@@ -313,7 +313,7 @@ begin
         P.OnMouseDown := FPaintBoxMouseDown;
         P.OnMouseUp := FPaintBoxMouseUp;
         P.OnMouseMove := FPaintBoxMouseMove;
-        P.Tag := Integer(F);
+        P.Tag := NativeInt(F);
         inc(X, P.Width);
         PaintList.Add(P);
       end;
@@ -358,7 +358,7 @@ begin
       P.OnMouseUp := GPaintBoxMouseUp;
       P.OnMouseMove := GPaintBoxMouseMove;
       P.PopupMenu := ViewFieldPopup;
-      P.Tag := Integer(V);
+      P.Tag := NativeInt(V);
       inc(X, P.Width{ - 20});
       GPaintList.Add(P);
       inc(Y, 8);
@@ -413,7 +413,7 @@ begin
       P.OnMouseUp := CPaintBoxMouseUp;
       P.OnMouseMove := CPaintBoxMouseMove;
       P.PopupMenu := ViewFieldPopup;
-      P.Tag := Integer(V);
+      P.Tag := NativeInt(V);
       inc(X, P.Width);
       CPaintList.Add(P);
     end;

--- a/source/o32sbar.pas
+++ b/source/o32sbar.pas
@@ -670,7 +670,7 @@ begin
   SendMessage(Handle, SB_SETBKCOLOR, 0, ColorToRGB(Color));
   UpdatePanels(True, False);
   if FSimpleText <> '' then
-    SendMessage(Handle, SB_SETTEXT, 255, Integer(PChar(FSimpleText)));
+    SendMessage(Handle, SB_SETTEXT, 255, lParam(PChar(FSimpleText)));
   if FSimplePanel then
     SendMessage(Handle, SB_SIMPLE, 1, 0);
 end;
@@ -767,12 +767,12 @@ end;
 
 procedure TO32CustomStatusBar.UpdateSimpleText;
 const
-  RTLReading: array[Boolean] of Integer = (0, SBT_RTLREADING);
+  RTLReading: array[Boolean] of DWORD = (0, SBT_RTLREADING);
 begin
   DoRightToLeftAlignment(FSimpleText, taLeftJustify, UseRightToLeftAlignment);
   if HandleAllocated then
     SendMessage(Handle, SB_SETTEXT, 255 or RTLREADING[UseRightToLeftReading],
-      Integer(PChar(FSimpleText)));
+      lParam(PChar(FSimpleText)));
 end;
 {=====}
 
@@ -885,7 +885,7 @@ begin
 
       if Style = spsContainer then begin
         FUpdateNeeded := True;
-        SendMessage(Handle, SB_GETRECT, Index, Integer(@PanelRect));
+        SendMessage(Handle, SB_GETRECT, Index, lParam(@PanelRect));
         Panels[Index].Container.Color := Color;;
         with Panels[Index].Container do begin
           Visible := true;
@@ -906,7 +906,7 @@ begin
       else begin
         if not Repaint then begin
           FUpdateNeeded := True;
-          SendMessage(Handle, SB_GETRECT, Index, Integer(@PanelRect));
+          SendMessage(Handle, SB_GETRECT, Index, lParam(@PanelRect));
           InvalidateRect(Handle, @PanelRect, True);
           Exit;
         end else
@@ -940,7 +940,7 @@ begin
               Insert(#9#9, S, 1);
           end;
 
-        SendMessage(Handle, SB_SETTEXT, Index or Flags, Integer(PChar(S)));
+        SendMessage(Handle, SB_SETTEXT, Index or Flags, lParam(PChar(S)));
 
       end; {Panel.Style = spsContainer - else}
     end; {Panels[index]}
@@ -964,8 +964,8 @@ begin
       if Count = 0 then
       begin
         PanelEdges[0] := -1;
-        SendMessage(Handle, SB_SETPARTS, 1, Integer(@PanelEdges));
-        SendMessage(Handle, SB_SETTEXT, 0, Integer(PChar('')));
+        SendMessage(Handle, SB_SETPARTS, 1, lParam(@PanelEdges));
+        SendMessage(Handle, SB_SETTEXT, 0, lParam(PChar('')));
       end else
       begin
         PanelPos := 0;
@@ -975,7 +975,7 @@ begin
           PanelEdges[I] := PanelPos;
         end;
         PanelEdges[Count - 1] := -1;
-        SendMessage(Handle, SB_SETPARTS, Count, Integer(@PanelEdges));
+        SendMessage(Handle, SB_SETPARTS, Count, lParam(@PanelEdges));
       end;
     end;
     for I := 0 to Count - 1 do begin

--- a/source/ovcBidi.pas
+++ b/source/ovcBidi.pas
@@ -112,9 +112,9 @@ begin
   if Len = 0 then
     Exit;
   SetLength(Buf, Len * SizeOf(Char)); // returned size is in TChars!
-  Len := GetLocaleInfo(LOCALE_USER_DEFAULT, LOCALE_FONTSIGNATURE, PChar(Buf), Length(Buf));
+  Len := GetLocaleInfo(LOCALE_USER_DEFAULT, LOCALE_FONTSIGNATURE, PChar(Buf), Len);
 
-  Move(PByte(Buf)^, LocaleSig, Min(Len, SizeOf(LocaleSig)));
+  Move(PByte(Buf)^, LocaleSig, Min(Len * SizeOf(Char), SizeOf(LocaleSig)));
 
   Result := LocaleSig.lsUsb[3] and $08000000 <> 0;
 end;

--- a/source/ovcRTF_Paint.pas
+++ b/source/ovcRTF_Paint.pas
@@ -119,7 +119,7 @@ begin
   Cookie.dwCount := 0;
   Cookie.dwSize := Length(RTF);
   Cookie.Text := PChar(RTF);
-  Stream.dwCookie := Integer(@Cookie);
+  Stream.dwCookie := NativeInt(@Cookie);
   Stream.dwError := 0;
   Stream.pfnCallback := EditStreamInCallback;
   OleCheck(Services.TxSendMessage(em_StreamIn, sf_RTF or sff_PlainRTF, lParam(@Stream), res));

--- a/source/ovcRTF_RichOle.pas
+++ b/source/ovcRTF_RichOle.pas
@@ -231,12 +231,12 @@ implementation
 function RichEdit_SetOleCallback(Wnd: HWND;
   const Intf: IRichEditOleCallback): Boolean;
 begin
-  Result := SendMessage(Wnd, EM_SETOLECALLBACK, 0, NativeInt(Intf)) <> 0;
+  Result := SendMessage(Wnd, EM_SETOLECALLBACK, 0, lParam(Intf)) <> 0;
 end;
 
 function RichEdit_GetOleInterface(Wnd: HWND; out Intf: IRichEditOle): Boolean;
 begin
-  Result := SendMessage(Wnd, EM_GETOLEINTERFACE, 0, NativeInt(@Intf)) <> 0;
+  Result := SendMessage(Wnd, EM_GETOLEINTERFACE, 0, lParam(@Intf)) <> 0;
 end;
 
 {$ENDIF}

--- a/source/ovcabtn.pas
+++ b/source/ovcabtn.pas
@@ -225,7 +225,7 @@ begin
 
     {if we get this message, we must be attached -- return self}
     if Msg = OM_ISATTACHED then
-      Result := NativeInt(Self);
+      Result := lResult(Self);
   end;
 end;
 

--- a/source/ovcae.pas
+++ b/source/ovcae.pas
@@ -827,12 +827,12 @@ end;
 
 procedure TOvcBaseArrayEditor.CreateParams(var Params: TCreateParams);
 const
-  ScrollBar : array[Boolean] of Integer = (0, WS_VSCROLL);
+  ScrollBar : array[Boolean] of DWORD = (0, WS_VSCROLL);
 begin
   inherited CreateParams(Params);
 
   with Params do
-    Style := Integer(Style) or
+    Style := DWORD(Style) or
       ScrollBar[FUseScrollBar] or BorderStyles[FBorderStyle];
 
   if NewStyleControls and Ctl3D and (FBorderStyle = bsSingle) then begin

--- a/source/ovcbcklb.pas
+++ b/source/ovcbcklb.pas
@@ -460,7 +460,7 @@ begin
       State := [odSelected];
     if (ItemIndex = TopIndex) and Focused then
       State := State + [odFocused];
-    SendMessage(Handle, LB_GETITEMRECT, TopIndex, NativeInt(@Rect));
+    SendMessage(Handle, LB_GETITEMRECT, TopIndex, lParam(@Rect));
     DrawItem(TopIndex, Rect, State);
   end;
 end;
@@ -571,7 +571,7 @@ begin
   I := ItemAtPos(P, True);
   if I > -1 then begin
     FillChar(R, SizeOf(R), #0);
-    SendMessage(Handle, LB_GETITEMRECT, I, NativeInt(@R));
+    SendMessage(Handle, LB_GETITEMRECT, I, lParam(@R));
     if (not BoxClickOnly) or ((Msg.XPos >= R.Left) and
        (Msg.XPos <= R.Left + ItemHeight - BoxMargin div 2)) then
       inherited
@@ -744,7 +744,7 @@ procedure TOvcBasicCheckList.InvalidateItem(Index : Integer);
 var
   R : TRect;
 begin
-  SendMessage(Handle, LB_GETITEMRECT, Index, NativeInt(@R));
+  SendMessage(Handle, LB_GETITEMRECT, Index, lParam(@R));
   InvalidateRect(Handle, @R, True);
 end;
 

--- a/source/ovcbtnhd.pas
+++ b/source/ovcbtnhd.pas
@@ -477,11 +477,11 @@ end;
 
 procedure TOvcButtonHeader.CreateParams(var Params : TCreateParams);
 const
-  BorderStyles: array[TBorderStyle] of Integer = (0, WS_BORDER);
+  BorderStyles: array[TBorderStyle] of DWORD = (0, WS_BORDER);
 begin
   inherited CreateParams(Params);
 
-  Params.Style := Integer(Params.Style) or BorderStyles[FBorderStyle];
+  Params.Style := DWORD(Params.Style) or BorderStyles[FBorderStyle];
   if NewStyleControls and Ctl3D and (FBorderStyle = bsSingle) then begin
     Params.Style := Params.Style and not WS_BORDER;
     Params.ExStyle := Params.ExStyle or WS_EX_CLIENTEDGE;

--- a/source/ovccache.pas
+++ b/source/ovccache.pas
@@ -71,7 +71,7 @@ unit OvcCache;
 
    The number of data items held in the cache is determined by the
    MaxCacheItems property and must be at least 2 and no more than
-   MaxLongInt. The number of items you want the cache to maintain
+   MaxInt. The number of items you want the cache to maintain
    depends on where that data is coming from, whether the data is
    in a file that is shared by others, and most importantly, through
    experimentation.
@@ -147,7 +147,7 @@ unit OvcCache;
      cache. You must assign a method to this event, otherwise the
      cache has no way to obtain the requested data.
 
-     Index is a number from 0 to MaxLongInt and can represent record
+     Index is a number from 0 to MaxInt and can represent record
      numbers corresponding to records in a data file or just about
      anything you want them to. The cache assumes that you will
      request items using the same index number that was used when the
@@ -427,7 +427,7 @@ var
     Hits : Integer;
     P    : PCacheRecord;
   begin
-    Hits := MaxLongInt;
+    Hits := MaxInt;
     Result := -1;
     for I := 0 to FList.Count-1 do begin
       P := PCacheRecord(FList.Items[I]);

--- a/source/ovccal.pas
+++ b/source/ovccal.pas
@@ -242,8 +242,9 @@ type
       dynamic;
     function DoOnGetDateEnabled(ADate : TDateTime) : Boolean;
       dynamic;
-    procedure DoOnMouseWheel(Shift : TShiftState; Delta, XPos, YPos : SmallInt);
-      override;
+    {DM - START CHANGE}
+    function DoMouseWheel(Shift: TShiftState; WheelDelta: integer; MousePos: TPoint): boolean; override;
+    {DM - END CHANGE}
     function IsReadOnly : Boolean;
       dynamic;
       {-return true if the calendar is in read-only mode}
@@ -872,12 +873,12 @@ end;
 
 procedure TOvcCustomCalendar.CreateParams(var Params : TCreateParams);
 const
-  BorderStyles : array[TBorderStyle] of Integer = (0, WS_BORDER);
+  BorderStyles : array[TBorderStyle] of DWORD = (0, WS_BORDER);
 begin
   inherited CreateParams(Params);
 
   with Params do begin
-    Style := Integer(Style) or BorderStyles[FBorderStyle];
+    Style := DWORD(Style) or BorderStyles[FBorderStyle];
     if clPopup then begin
       Style := WS_POPUP or WS_BORDER;
       WindowClass.Style := WindowClass.Style or CS_SAVEBITS;
@@ -950,35 +951,38 @@ begin
     FOnGetDateEnabled(Self, ADate, Result);
 end;
 
-procedure TOvcCustomCalendar.DoOnMouseWheel(Shift : TShiftState; Delta, XPos, YPos : SmallInt);
+{DM - START CHANGE}
+function TOvcCustomCalendar.DoMouseWheel(Shift: TShiftState; WheelDelta: integer; MousePos: TPoint): boolean;
 var
   Key : Word;
 begin
-  inherited DoOnMouseWheel(Shift, Delta, XPos, YPos);
+  result := inherited DoMouseWheel(Shift, WheelDelta, MousePos);
+  if result then Exit;
 
-  if Abs(Delta) = WHEEL_DELTA then begin
+  if Abs(WheelDelta) = WHEEL_DELTA then begin
     {inc/dec month}
-    if Delta < 0 then
+    if WheelDelta < 0 then
       Key := VK_NEXT
     else
       Key := VK_PRIOR;
     KeyDown(Key, []);
-  end else if Abs(Delta) > WHEEL_DELTA then begin
+  end else if Abs(WheelDelta) > WHEEL_DELTA then begin
     {inc/dec year}
-    if Delta < 0 then
+    if WheelDelta < 0 then
       Key := VK_NEXT
     else
       Key := VK_PRIOR;
     KeyDown(Key, [ssCtrl]);
-  end else if Abs(Delta) < WHEEL_DELTA then begin
+  end else if Abs(WheelDelta) < WHEEL_DELTA then begin
     {inc/dec Week}
-    if Delta < 0 then
+    if WheelDelta < 0 then
       Key := VK_DOWN
     else
       Key := VK_UP;
     KeyDown(Key, []);
   end;
 end;
+{DM - END CHANGE}
 
 function TOvcCustomCalendar.GetAsDateTime : TDateTime;
 begin

--- a/source/ovccklb.pas
+++ b/source/ovccklb.pas
@@ -605,7 +605,7 @@ procedure TOvcCheckList.InvalidateItem(Index : Integer);
 var
   R : TRect;
 begin
-  SendMessage(Handle, LB_GETITEMRECT, Index, NativeInt(@R));
+  SendMessage(Handle, LB_GETITEMRECT, Index, lParam(@R));
   InvalidateRect(Handle, @R, True);
 end;
 
@@ -802,7 +802,7 @@ begin
   I := ItemAtPos(P, True);
   FillChar(R, SizeOf(R), 0);
   if I > -1 then
-    SendMessage(Handle, LB_GETITEMRECT, I, NativeInt(@R));
+    SendMessage(Handle, LB_GETITEMRECT, I, lParam(@R));
 
   {eat click if clicking on the check box}
   if (Msg.XPos > R.Left + ItemHeight - BoxMargin div 2) then begin

--- a/source/ovccmbx.pas
+++ b/source/ovccmbx.pas
@@ -115,7 +115,9 @@ type
     {event variables}
     FAfterEnter   : TNotifyEvent;
     FAfterExit    : TNotifyEvent;
-    FOnMouseWheel : TMouseWheelEvent;
+    {DM - START CHANGE}
+    // removed FOnMouseWheel : TMouseWheelEvent;
+    {DM - END CHANGE}
     FOnSelChange  : TNotifyEvent;        {called when the selection changes}
 
     {internal variables}
@@ -190,8 +192,9 @@ type
       message WM_KILLFOCUS;
     procedure WMMeasureItem(var Message : TMessage);
       message WM_MEASUREITEM;
-    procedure WMMouseWheel(var Msg : TMessage);
-      message WM_MOUSEWHEEL;
+    {DM - START CHANGE}
+    // removed procedure WMMouseWheel(var Msg : TMessage); message WM_MOUSEWHEEL;
+    {DM - END CHANGE}
     procedure WMSetFocus(var Msg : TWMSetFocus);
       message WM_SETFOCUS;
 
@@ -217,8 +220,9 @@ type
     procedure CreateParams(var Params: TCreateParams); override;
     procedure CreateWnd; override;
     procedure DestroyWnd; override;
-    procedure DoOnMouseWheel(Shift: TShiftState;
-      Delta, XPos, YPos: SmallInt); dynamic;
+    {DM - START CHANGE}
+    // removed function DoOnMouseWheel
+    {DM - END CHANGE}
     procedure DoExit; override;
     procedure DrawItem(Index: Integer; ItemRect: TRect;
       State: TOwnerDrawState); override;
@@ -270,8 +274,9 @@ type
     {events}
     property AfterEnter: TNotifyEvent read FAfterEnter write FAfterEnter;
     property AfterExit: TNotifyEvent read FAfterExit write FAfterExit;
-    property OnMouseWheel: TMouseWheelEvent read FOnMouseWheel
-      write FOnMouseWheel;
+    {DM - START CHANGE}
+    // removed property OnMouseWheel: TMouseWheelEvent read FOnMouseWheel write FOnMouseWheel;
+    {DM - END CHANGE}
     property OnSelectionChange: TNotifyEvent read FOnSelChange
       write FOnSelChange;
   public
@@ -310,6 +315,7 @@ type
   TOvcComboBox = class(TOvcBaseComboBox)
   published
     {properties}
+    property Align;
     property Anchors;
     property Constraints;
     property DragKind;
@@ -695,7 +701,7 @@ begin
     ItemIndex := SendMessage(Handle,
                              CB_FINDSTRINGEXACT,
                              FMRUList.Items.Count - 1,
-                             Integer(SrchText));
+                             LPARAM(SrchText));
   finally
     StrDispose(SrchText); // FreeMem(SrchText, L);
   end;
@@ -892,12 +898,9 @@ begin
   inherited DoExit;
 end;
 
-procedure TOvcBaseComboBox.DoOnMouseWheel(Shift : TShiftState;
-                                   Delta, XPos, YPos : SmallInt);
-begin
-  if Assigned(FOnMouseWheel) then
-    FOnMouseWheel(Self, Shift, Delta, XPos, YPos);
-end;
+{DM - START CHANGE}
+// removed function TOvcBaseComboBox.DoOnMouseWheel
+{DM - END CHANGE}
 
 procedure TOvcBaseComboBox.DrawItem(Index : Integer; ItemRect: TRect;
                                      State : TOwnerDrawState);
@@ -1015,7 +1018,7 @@ begin
           {this will search for the first matching item}
           Index := SendMessage(Handle, CB_FINDSTRING,
                                FMRUList.Items.Count - 1,
-                                 NativeInt(SrchText));
+                                 lParam(SrchText));
         finally
           StrDispose(SrchText); //FreeMem(SrchText, length(Text) + 1);
         end;
@@ -1392,7 +1395,7 @@ begin
       ItemIndex := SendMessage(Handle,
                                CB_FINDSTRINGEXACT,
                                0,
-                               NativeInt(SrchText));
+                               lParam(SrchText));
     finally
       StrDispose(SrchText); // FreeMem(SrchText, L);
     end;
@@ -1552,15 +1555,9 @@ begin
   end;
 end;
 
-procedure TOvcBaseComboBox.WMMouseWheel(var Msg : TMessage);
-begin
-  inherited;
-
-  with Msg do
-    DoOnMouseWheel(KeysToShiftState(LOWORD(wParam)) {fwKeys},
-                   HIWORD(wParam) {zDelta},
-                   LOWORD(lParam) {xPos},   HIWORD(lParam) {yPos});
-end;
+{DM - START CHANGE}
+// removed procedure TOvcBaseComboBox.WMMouseWheel(var Msg : TMessage);
+{DM - END CHANGE}
 
 procedure TOvcBaseComboBox.WMSetFocus(var Msg : TWMSetFocus);
 begin

--- a/source/ovcdbae.pas
+++ b/source/ovcdbae.pas
@@ -1001,13 +1001,13 @@ end;
 
 procedure TOvcBaseDbArrayEditor.CreateParams(var Params: TCreateParams);
 const
-  ScrollBar : array[Boolean] of Integer = (0, WS_VSCROLL);
+  ScrollBar : array[Boolean] of DWORD = (0, WS_VSCROLL);
 begin
   inherited CreateParams(Params);
 
   with Params do
-    Style := Integer(Style) or
-      ScrollBar[FUseScrollBar] or BorderStyles[FBorderStyle];
+    Style := DWORD(Style) or
+      DWORD(ScrollBar[FUseScrollBar]) or DWORD(BorderStyles[FBorderStyle]);
 
   if NewStyleControls and Ctl3D and (FBorderStyle = bsSingle) then begin
     Params.Style := Params.Style and not WS_BORDER;

--- a/source/ovcdbcl.pas
+++ b/source/ovcdbcl.pas
@@ -647,7 +647,7 @@ end;
 
 procedure TOvcDbColumnList.CMGetDataLink(var Msg : TMessage);
 begin
-  Msg.Result := Integer(FDataLink);
+  Msg.Result := lResult(FDataLink);
 end;
 
 constructor TOvcDbColumnList.Create(AOwner : TComponent);
@@ -721,8 +721,8 @@ begin
   inherited CreateParams(Params);
 
   with Params do
-    Style := Integer(Style) or ScrollBarStyles[FScrollBars]
-                   or BorderStyles[FBorderStyle];
+    Style := DWORD(Style) or DWORD(ScrollBarStyles[FScrollBars])
+                   or DWORD(BorderStyles[FBorderStyle]);
 
   if NewStyleControls and Ctl3D and (FBorderStyle = bsSingle) then begin
     Params.Style := Params.Style and not WS_BORDER;

--- a/source/ovcdbdlb.pas
+++ b/source/ovcdbdlb.pas
@@ -142,7 +142,7 @@ implementation
 
 procedure TOvcDbDisplayLabel.CMGetDataLink(var Msg : TMessage);
 begin
-  Msg.Result := Integer(FDataLink);
+  Msg.Result := lResult(FDataLink);
 end;
 
 constructor TOvcDbDisplayLabel.Create(AOwner : TComponent);

--- a/source/ovcdbnum.pas
+++ b/source/ovcdbnum.pas
@@ -247,7 +247,7 @@ end;
 
 procedure TOvcCustomDbNumberEdit.CMGetDataLink(var Message : TMessage);
 begin
-  Message.Result := Integer(FDataLink);
+  Message.Result := lResult(FDataLink);
 end;
 
 constructor TOvcCustomDbNumberEdit.Create(AOwner : TComponent);

--- a/source/ovcdbplb.pas
+++ b/source/ovcdbplb.pas
@@ -156,7 +156,7 @@ implementation
 
 procedure TOvcDbPictureLabel.CMGetDataLink(var Msg : TMessage);
 begin
-  Msg.Result := Integer(FDataLink);
+  Msg.Result := lResult(FDataLink);
 end;
 
 constructor TOvcDbPictureLabel.Create(AOwner : TComponent);

--- a/source/ovcdbrpv.pas
+++ b/source/ovcdbrpv.pas
@@ -488,7 +488,7 @@ procedure TOvcDbReportView.MoveDataPointer(P : Pointer);
 begin
   inc(InMove);
   try
-    FDataLink.ActiveRecord := Integer(P) - 1;
+    FDataLink.ActiveRecord := NativeInt(P) - 1;
   finally
     dec(InMove);
   end;
@@ -596,6 +596,7 @@ var
   F1,F2 : double;
   ActiveRecord: Integer;
 begin
+  result := 0;
   ActiveRecord := FDataLink.ActiveRecord;
   try
     case TField(FieldList[FieldIndex]).DataType of

--- a/source/ovcdbtim.pas
+++ b/source/ovcdbtim.pas
@@ -241,7 +241,7 @@ end;
 
 procedure TOvcCustomDbTimeEdit.CMGetDataLink(var Message : TMessage);
 begin
-  Message.Result := Integer(FDataLink);
+  Message.Result := lResult(FDataLink);
 end;
 
 constructor TOvcCustomDbTimeEdit.Create(AOwner : TComponent);

--- a/source/ovcdlm.pas
+++ b/source/ovcdlm.pas
@@ -44,7 +44,7 @@ uses
 
 {.$DEFINE OvcDlmDebug}
 const
-  dlmMaxKeys = 64;
+  dlmMaxKeys = MaxByte;
 
 { TOvcPoolManager }
 
@@ -198,7 +198,7 @@ type
 
 { TOvcSortedList }
 type
-  TOvcMultiCompareFunc = function(Key : Integer; I1,I2 : Pointer) : Integer of object;
+  TOvcMultiCompareFunc = function(Key : NativeInt; I1,I2 : Pointer) : Integer of object;
   TOvcSortedList = class(TOvcList)
   protected
     FCompareFunc : TOvcMultiCompareFunc;
@@ -439,10 +439,9 @@ begin
   Result := Pool.NewItem;
 end;
 
-function TOvcList.Compare(Sender: TOvcPageTree; UserData, Key1,
-  Key2: Pointer): Integer;
+function TOvcList.Compare(Sender: TOvcPageTree; UserData, Key1, Key2: Pointer): Integer;
 begin
-  Result := NativeUInt(POvcListNode(Key1)^.Item) - NativeUInt(POvcListNode(Key2)^.Item);
+  Result := Integer(NativeUInt(POvcListNode(Key1)^.Item) - NativeUInt(POvcListNode(Key2)^.Item));
 end;
 
 function TOvcList.First(var Node: PovcListNode): Boolean;
@@ -580,12 +579,12 @@ begin
   if Key1 = Key2 then
     Result := 0
   else begin
-    Result := FCompareFunc(Integer(UserData) - 1, POvcListNode(Key1).Item, POvcListNode(Key2).Item);
+    Result := FCompareFunc(NativeInt(UserData) - 1, POvcListNode(Key1).Item, POvcListNode(Key2).Item);
     if Result = 0 then
       if Key1 = Key2 then
         raise Exception.Create('Internal error')
       else
-        Result := NativeUInt(Key1) - NativeUInt(Key2);
+        Result := Integer(NativeUInt(Key1) - NativeUInt(Key2));
   end;
 end;
 
@@ -596,7 +595,7 @@ var
   i: Integer;
 begin
   for i := Count - 1 downto 0 do
-    POvcListNode(DataArray[i]).IndexPages[Integer(UserData)] := NewPage;
+    POvcListNode(DataArray[i]).IndexPages[Byte(UserData)] := NewPage;
 end;
 
 procedure TOvcSortedList.SetCurrentKey(Value: Integer);
@@ -766,7 +765,7 @@ var
   i,NewSlot : Integer;
 begin
   if CacheCount >= FCacheSize then begin
-    Old := MaxLongInt;
+    Old := MaxInt;
     NewSlot := -1;
     for i := 0 to pred(CacheCount) do
       if TimeStamp[i] < Old then begin

--- a/source/ovcdvcbx.pas
+++ b/source/ovcdvcbx.pas
@@ -143,31 +143,25 @@ uses
   ovcStr;
 
 function GetVolume(DriveChar: Char): string;
-const
-  MaxVolSize = 260;
 var
   Path : array [0..3] of Char;
   NU, VolSize : DWord;
-  Vol : PChar;
+  Vol : array[0..MAX_PATH] of Char;
 begin
   Path[0] := DriveChar;
   Path[1] := ':';
   Path[2] := #0;
-  VolSize := MaxVolSize;
-  GetMem(Vol, MaxVolSize * SizeOf(Char));
   Vol[0] := #0;
   Result := '';
-  try
-    if WNetGetConnection(Path, Vol, VolSize) = WN_SUCCESS then
-      Result := StrPas(Vol)
-    else begin
-      if GetVolumeInformation(PChar(DriveChar + ':\'),
-        Vol, MAX_PATH, nil, NU, NU, nil, 0) then
-        Result := Vol;
-      Result := Format('[%s]',[Result]);
-    end;
-  finally
-    FreeMem(Vol, MaxVolSize);
+  VolSize := Length(Vol);
+  if WNetGetConnection(Path, Vol, VolSize) = WN_SUCCESS then
+    Result := StrPas(Vol)
+  else begin
+    VolSize := Length(Vol);
+    if GetVolumeInformation(PChar(DriveChar + ':\'),
+      Vol, VolSize, nil, NU, NU, nil, 0) then
+      Result := Vol;
+    Result := Format('[%s]',[Result]);
   end;
 end;
 
@@ -222,7 +216,7 @@ begin
   ClearItems;
   SavedErrorMode := SetErrorMode(SEM_FAILCRITICALERRORS);
   try
-    SendMessage(Handle, CB_DIR, DDL_Drives + DDL_Exclusive, NativeInt(PChar('*.*')));
+    SendMessage(Handle, CB_DIR, DDL_Drives + DDL_Exclusive, lParam(PChar('*.*')));
     if Items.Count > 0 then
       for I := 0 to Pred(Items.Count) do begin
         DriveChar := UpCase(Items[I][3]);

--- a/source/ovceditn.pas
+++ b/source/ovceditn.pas
@@ -66,8 +66,8 @@ type
   TUndoRec = packed record
     PNum     : Integer;    {paragraph number}
     PPos     : Integer;    {position in paragraph}
-    DSize    : Word;       {data size in characters (unicode: not bytes)}
-    PrevSize : Word;       {size of previous record}
+    DSize    : Cardinal;   {data size in characters (unicode: not bytes)}
+    PrevSize : Cardinal;   {size of previous record}
     Flags    : Byte;       {contains undo type and flags}
     LinkNum  : Byte;       {link number}
     Data     : record end; {data-dynamically allocated}
@@ -115,14 +115,14 @@ type
 
   TParaNode = class(TObject)
   public
-    BufSize   : Word;       {size of buffer}
+    BufSize   : Cardinal;   {size of buffer}
     LineCount : Integer;    {number of lines in this paragraph}
     Map       : PLineMap;   {pointer to line map}
     MapSize   : Word;       {number of elements in line map}
     Next      : TParaNode;  {next paragraph in list}
     Prev      : TParaNode;  {previous paragraph in list}
-    S         : PChar;  {text of paragraph; nil if empty}
-    SLen      : Word;       {current length}
+    S         : PChar;      {text of paragraph; nil if empty}
+    SLen      : Integer;    {current length}
 
     constructor Init(P       : PChar;
                      WrapCol : Integer;
@@ -397,10 +397,11 @@ constructor TParaNode.InitLen(P : PChar; Len : Word;
                               WrapCol, TabSize : Integer);
   {-Create paragraph with Len characters from P^}
 var
-  Size : Word;
+  Size : Cardinal;
 begin
   inherited Create;
 
+  S := nil;
   Map := nil;
   Next := nil;
   Prev := nil;
@@ -409,7 +410,6 @@ begin
 
   {make copy of line}
   if Size = 1 then begin
-    S := nil;
     BufSize := 0;
   end else begin
     BufSize := (Size+7) and $FFF8;

--- a/source/ovceditp.pas
+++ b/source/ovceditp.pas
@@ -519,7 +519,7 @@ begin
   Dec(LineCount, LC-PPN.LineCount);
   FLine := Pred(LastN)+FL;
   if PPN.LineCount <> LC then
-    LLine := MaxLongInt
+    LLine := MaxInt
   else
     LLine := Pred(LastN)+LL;
   FixMarkersDeletedText(Editor, P, Pos, Count);
@@ -756,8 +756,8 @@ begin
   ParaCount := 0;
   LineCount := 1;
   CharCount := 0;
-  MaxParas := MaxLongInt;
-  MaxBytes := MaxLongInt;
+  MaxParas := MaxInt;
+  MaxBytes := MaxInt;
   MaxParaLen := High(SmallInt);
   WordWrap := Wrap;
   WrapColumn := 80;
@@ -860,7 +860,7 @@ begin
       FLine := FindLineByPara(OP, OPos, I);
       if FLine > 1 then
         Dec(FLine);
-      LLine := MaxLongInt;
+      LLine := MaxInt;
     end;
   finally
     FreeMem(Buffer);
@@ -945,7 +945,7 @@ begin
     Inc(LineCount, PPN.LineCount-LC);
     FLine := Pred(LastN)+FL;
     if PPN.LineCount <> LC then
-      LLine := MaxLongInt
+      LLine := MaxInt
     else
       LLine := Pred(LastN)+LL;
     FixMarkersInsertedText(Editor, P, Pos, SLen);
@@ -1229,8 +1229,8 @@ begin
   if (Paras <> 0) or (P > MaxParas) then begin
     if (P > MaxParas) or (ParaLength(ParaCount) <> 0) then
       M := MaxParas
-    else if MaxParas = MaxLongInt then
-      M := MaxLongInt
+    else if MaxParas = MaxInt then
+      M := MaxInt
     else
       M := MaxParas+1;
     if (ParaCount+Paras > M) then begin
@@ -1457,7 +1457,7 @@ begin
 
     FLine := Pred(LastN)+FL;
     if PPN.LineCount <> LC then
-      LLine := MaxLongInt
+      LLine := MaxInt
     else
       LLine := Pred(LastN)+LL;
 
@@ -1871,7 +1871,7 @@ function TOvcUndoBuffer.NthRec(N : Integer) : PUndoRec; register;
 begin
   result := PUndoRec(self.Buffer);
   while N>1 do begin
-    result := PUndoRec(Cardinal(result) + UndoRecSize + result^.DSize*SizeOf(Char));
+    result := PUndoRec(NativeUInt(result) + UndoRecSize + result^.DSize*SizeOf(Char));
     Dec(N);
   end;
 end;
@@ -2012,7 +2012,7 @@ begin
   D := PChar(@Last^.Data);
   case UT of
     utInsert :
-      Result := (Last^.PNum = P) and (Pos = Last^.PPos+Last^.DSize);
+      Result := (Last^.PNum = P) and (Cardinal(Pos) = Cardinal(Last^.PPos)+Last^.DSize);
     utDelete :
       if (Last^.PNum = P) then
         if (Pos = Last^.PPos) then

--- a/source/ovcfiler.pas
+++ b/source/ovcfiler.pas
@@ -323,7 +323,7 @@ begin
         if (Items[K]^.PI.PropType^.Kind = tkClass) and
            (CompareText(string(Items[K]^.PI.PropType^.Name), TOvcCollection.ClassName) = 0) then begin
           {get the collection instance}
-          C := TOvcCollection(GetOrdProp(AObject, PPropInfo(Items[K])));
+          C := TOvcCollection(GetInt64Prop(AObject, PPropInfo(Items[K])));
           for I := 0 to C.Count-1 do begin
             Props := TOvcPropertyList.Create(C.Item[I], tkProperties, string(Items[K]^.PI.Name)
               + '[' + IntToStr(I) + ']');
@@ -514,7 +514,7 @@ var
   PropS : TOvcPropertyList;
 begin
   Result := '';
-  Obj := TObject(GetOrdProp(PropInfo^.AObject, PPropInfo(PropInfo)));
+  Obj := TObject(GetInt64Prop(PropInfo^.AObject, PPropInfo(PropInfo)));
 
   if (Obj <> nil) and (Obj is TComponent) then exit;
 
@@ -568,13 +568,13 @@ begin
 end;
 
 type
-  TCardinalSet = set of 0..SizeOf(Cardinal) * 8 - 1;
+  TCardinalSet = set of 0..(SizeOf(Cardinal) * 8 - 1);
 
 function TOvcDataFiler.GetSetProperty(PropInfo : PExPropInfo) : string;
 var
   TypeInfo : PTypeInfo;
   W        : Cardinal;
-  I        : Integer;
+  I        : Cardinal;
 begin
   Result := '[';
   W := GetOrdProp(PropInfo^.AObject, PPropInfo(PropInfo));
@@ -610,7 +610,7 @@ var
   SectName : string;
 begin
   Result := '';
-  List := TObject(GetOrdProp(PropInfo^.AObject, PPropInfo(PropInfo)));
+  List := TObject(GetInt64Prop(PropInfo^.AObject, PPropInfo(PropInfo)));
   SectName := Format('%s.%s', [Section, GetItemName(string(PropInfo^.PI.Name))]);
   EraseSection(SectName);
   if (List is TStrings) and (TStrings(List).Count > 0) then begin
@@ -741,7 +741,7 @@ begin
     C := S[1]
   else
     C := #0;
-  SetOrdProp(PropInfo^.AObject, PPropInfo(PropInfo), Integer(C));
+  SetOrdProp(PropInfo^.AObject, PPropInfo(PropInfo), Ord(C));
 end;
 
 procedure TOvcDataFiler.SetClassProperty({const S : string; }PropInfo : PExPropInfo);
@@ -751,7 +751,7 @@ var
   I      : Integer;
   Obj    : TObject;
 begin
-  Obj := TObject(GetOrdProp(PropInfo^.AObject, PPropInfo(PropInfo)));
+  Obj := TObject(GetInt64Prop(PropInfo^.AObject, PPropInfo(PropInfo)));
   if (Obj <> nil) and (Obj is TStrings) then
     SetStringsProperty({S, }PropInfo);
   Loader := CreateDataFiler;
@@ -808,8 +808,8 @@ const
 var
   TypeInfo : PTypeInfo;
   W        : Cardinal;
-  I, N     : Integer;
-  Count    : Integer;
+  N        : Cardinal;
+  I, Count : Integer;
   EnumName : string;
 begin
   W := 0;
@@ -850,7 +850,7 @@ var
   I, Cnt   : Integer;
   SectName : string;
 begin
-  List := TObject(GetOrdProp(PropInfo^.AObject, PPropInfo(PropInfo)));
+  List := TObject(GetInt64Prop(PropInfo^.AObject, PPropInfo(PropInfo)));
   if (List is TStrings) then begin
     SectName := Format('%s.%s', [Section, GetItemName(string(PropInfo^.PI.Name))]);
     Cnt := StrToIntDef(Trim(ReadString(SectName, 'Count', '0')), 0);
@@ -874,7 +874,7 @@ end;
 
 procedure TOvcDataFiler.SetWCharProperty(const S : string; PropInfo : PExPropInfo);
 begin
-  SetOrdProp(PropInfo^.AObject, PPropInfo(PropInfo), NativeInt(S[1]));
+  SetOrdProp(PropInfo^.AObject, PPropInfo(PropInfo), Ord(S[1]));
 end;
 
 procedure TOvcDataFiler.StoreAllProperties(AObject : TObject);

--- a/source/ovcftcbx.pas
+++ b/source/ovcftcbx.pas
@@ -414,7 +414,7 @@ begin
     VK_DOWN, VK_UP:
       begin
         { Update the preview control's font AFTER the selection has been updated }
-        PostMessage(Handle, OM_FONTUPDATEPREVIEW, 0, NativeInt(Self));
+        PostMessage(Handle, OM_FONTUPDATEPREVIEW, 0, lParam(Self));
       end;
   end;
 
@@ -455,10 +455,10 @@ begin
   DC := GetDC(0);
   TempList := TStringList.Create;
   try
-    EnumFontFamilies(DC, nil, @EnumFontFamProc, Integer(Self));      //SZ FIXME EnumFontFamilies is 16-bit compatibility function
+    EnumFontFamilies(DC, nil, @EnumFontFamProc, lParam(Self));      //SZ FIXME EnumFontFamilies is 16-bit compatibility function
     if (Printer.Printers.Count > 0) and (Printer.Handle > 0) then
       EnumFontFamilies(Printer.Handle, nil, @EnumPrinterFontFamProc,
-        Integer(Self));
+        NativeInt(Self));
     TempList.Assign(Items);
     TempList.Sort;
     Items.Assign(TempList);

--- a/source/ovcfxfnt.pas
+++ b/source/ovcfxfnt.pas
@@ -167,7 +167,7 @@ procedure RefreshFixedFontNames;
     FixedFontNames.Clear;
     DC := GetDC(0);
     try
-      EnumFontFamilies(DC, nil, @EnumFixedFontsProc, integer(FixedFontNames));
+      EnumFontFamilies(DC, nil, @EnumFixedFontsProc, NativeInt(FixedFontNames));
     finally
       ReleaseDC(0, DC);
     end;

--- a/source/ovcfxfpe.pas
+++ b/source/ovcfxfpe.pas
@@ -95,13 +95,13 @@ begin
   try
     FontDialog := TFontDialog.Create(Application);
     FF := TOvcFixedFont.Create;
-    FF.Assign(TOvcFixedFont(GetOrdValue));
+    FF.Assign(TOvcFixedFont(GetInt64Value));
     FontDialog.Font := FF.Font;
     FontDialog.Options :=
         FontDialog.Options + [fdForceFontExist, fdFixedPitchOnly];
     if FontDialog.Execute then begin
       FF.Font.Assign(FontDialog.Font);
-      SetOrdValue(NativeInt(FF));
+      SetInt64Value(Int64(FF));
     end;
   finally
     FontDialog.Free;

--- a/source/ovcislb.pas
+++ b/source/ovcislb.pas
@@ -395,7 +395,7 @@ begin
   inherited CreateParams(Params);
 
   with Params do
-    Style := Integer(Style) or BorderStyles[FBorderStyle];
+    Style := DWORD(Style) or BorderStyles[FBorderStyle];
 
   if NewStyleControls and Ctl3D and (FBorderStyle = bsSingle) then begin
     Params.Style := Params.Style and not WS_BORDER;

--- a/source/ovcnbk.pas
+++ b/source/ovcnbk.pas
@@ -742,7 +742,7 @@ end;
 
 procedure TOvcNotebook.CMDesignHitTest(var Msg : TCMDesignHitTest);
 begin
-  Msg.Result := NativeInt(tabOverTab);
+  Msg.Result := lResult(tabOverTab);
 end;
 
 procedure TOvcNotebook.CMDialogChar(var Msg : TCMDialogChar);
@@ -1756,13 +1756,12 @@ begin
   {adjust size of all contained pages to fit our client area}
   L := 0;
   T := 0;
-  W := 0;
-  H := 0;
-
   if TabHeight = 0 then begin
     W := Self.Width;
     H := Self.Height;
   end else begin
+    W := 0;
+    H := 0;
     case FTabOrientation of
       toTop :
         begin

--- a/source/ovcnf.pas
+++ b/source/ovcnf.pas
@@ -834,8 +834,8 @@ var
 
   procedure IncDecValueLongInt;
   var
-    L : NativeInt;
-    S    : TEditString;
+    L : Integer;
+    S : TEditString;
   begin
     pbStripPicture(S, efEditSt);
 
@@ -1082,17 +1082,17 @@ var
     if TransferFlag = otf_GetData then begin
       pbStripPicture(S, efEditSt);
 
-      if not efStr2Long(S, NativeInt(DataPtr^)) then
-        NativeInt(DataPtr^) := 0;
+      if not efStr2Long(S, Integer(DataPtr^)) then
+        Integer(DataPtr^) := 0;
     end else begin
-      efLong2Str(S, NativeInt(DataPtr^));
+      efLong2Str(S, Integer(DataPtr^));
       pbMergePicture(efEditSt, S);
     end;
   end;
 
   procedure TransferWord;
   var
-    L      : NativeInt;
+    L      : Integer;
     S      : TEditString;
   begin
     if TransferFlag = otf_GetData then begin
@@ -1110,7 +1110,7 @@ var
 
   procedure TransferInteger;
   var
-    L      : NativeInt;
+    L      : Integer;
     S      : TEditString;
   begin
     if TransferFlag = otf_GetData then begin
@@ -1128,7 +1128,7 @@ var
 
   procedure TransferByte;
   var
-    L      : NativeInt;
+    L      : Integer;
     S      : TEditString;
   begin
     if TransferFlag = otf_GetData then begin
@@ -1146,7 +1146,7 @@ var
 
   procedure TransferShortInt;
   var
-    L      : NativeInt;
+    L      : Integer;
     S      : TEditString;
   begin
     if TransferFlag = otf_GetData then begin
@@ -1348,7 +1348,7 @@ function TOvcCustomNumericField.efValidateField : Word;
 
   procedure ValidateLongInt;
   var
-    L : NativeInt;
+    L    : Integer;
     S    : TEditString;
   begin
     pbStripPicture(S, efEditSt);
@@ -1368,7 +1368,7 @@ function TOvcCustomNumericField.efValidateField : Word;
 
   procedure ValidateWord;
   var
-    L : NativeInt;
+    L : Integer;
     W : Word;
     S    : TEditString;
   begin
@@ -1390,8 +1390,8 @@ function TOvcCustomNumericField.efValidateField : Word;
 
   procedure ValidateInteger;
   var
-    L : NativeInt;
-    I : Integer;
+    L    : Integer;
+    I    : Integer;
     S    : TEditString;
   begin
     pbStripPicture(S, efEditSt);
@@ -1412,8 +1412,8 @@ function TOvcCustomNumericField.efValidateField : Word;
 
   procedure ValidateByte;
   var
-    L : NativeInt;
-    B : Byte;
+    L    : Integer;
+    B    : Byte;
     S    : TEditString;
   begin
     pbStripPicture(S, efEditSt);
@@ -1434,8 +1434,8 @@ function TOvcCustomNumericField.efValidateField : Word;
 
   procedure ValidateShortInt;
   var
-    L  : NativeInt;
-    Si : Byte;
+    L    : Integer;
+    Si   : Byte;
     S    : TEditString;
   begin
     pbStripPicture(S, efEditSt);

--- a/source/ovcoutln.pas
+++ b/source/ovcoutln.pas
@@ -288,8 +288,8 @@ type
     procedure Click; override;
     procedure DblClick; override;
     function CalcMaxWidth: Integer;
-    function CompareNodesGlobal(Key : Integer; I1,I2 : Pointer) : Integer;
-    function CompareNodesLocal(Key : Integer; I1,I2 : Pointer) : Integer;
+    function CompareNodesGlobal(Key : NativeInt; I1,I2 : Pointer) : Integer;
+    function CompareNodesLocal(Key : NativeInt; I1,I2 : Pointer) : Integer;
     procedure DoActiveChange(OldNode, NewNode: TOvcOutlineNode); virtual;
     function DoDrawCheck(Canvas : TCanvas; Node: TOvcOutlineNode;
               Rect : TRect; Style : TOvcOlNodeStyle; Checked : Boolean) : Boolean; virtual;
@@ -1308,8 +1308,7 @@ asm
   sub eax, edx
 end;
 
-function TOvcCustomOutline.CompareNodesGlobal(Key: Integer; I1,
-  I2: Pointer): Integer;
+function TOvcCustomOutline.CompareNodesGlobal(Key: NativeInt; I1, I2: Pointer): Integer;
 begin
   Result := 0;
 
@@ -1329,8 +1328,7 @@ begin
 
 end;
 
-function TOvcCustomOutline.CompareNodesLocal(Key: Integer; I1,
-  I2: Pointer): Integer;
+function TOvcCustomOutline.CompareNodesLocal(Key: NativeInt; I1, I2: Pointer): Integer;
 begin
   Result := 0;
 

--- a/source/ovcpf.pas
+++ b/source/ovcpf.pas
@@ -1517,7 +1517,7 @@ var
 
   procedure IncDecValueLongInt;
   var
-    L : NativeInt;
+    L : Integer;
   begin
     pbStripPicture(S, efEditSt);
 
@@ -2020,7 +2020,7 @@ var
     if TransferFlag = otf_GetData then begin
       pbStripPicture(S, efEditSt);
 
-      if not efStr2Long(S, NativeInt(DataPtr^)) then
+      if not efStr2Long(S, Integer(DataPtr^)) then
         Integer(DataPtr^) := 0;
     end else begin
       efLong2Str(S, Integer(DataPtr^));
@@ -2031,7 +2031,7 @@ var
   procedure TransferWord;
     {-transfer data to or from Word fields}
   var
-    L : NativeInt;
+    L : Integer;
     S : TEditString;
   begin
     if TransferFlag = otf_GetData then begin
@@ -2050,7 +2050,7 @@ var
   procedure TransferInteger;
     {-transfer data to or from Integer fields}
   var
-    L : NativeInt;
+    L : Integer;
     S : TEditString;
   begin
     if TransferFlag = otf_GetData then begin
@@ -2069,7 +2069,7 @@ var
   procedure TransferByte;
     {-transfer data to or from Byte fields}
   var
-    L : NativeInt;
+    L : Integer;
     S : TEditString;
   begin
     if TransferFlag = otf_GetData then begin
@@ -2088,7 +2088,7 @@ var
   procedure TransferShortInt;
     {-transfer data to or from ShortInt fields}
   var
-    L : NativeInt;
+    L : Integer;
     S : TEditString;
   begin
     if TransferFlag = otf_GetData then begin
@@ -2425,7 +2425,7 @@ var
 
   procedure ValidateLongInt;
   var
-    L : NativeInt;
+    L : Integer;
   begin
     pbStripPicture(S, efEditSt);
 
@@ -2444,7 +2444,7 @@ var
 
   procedure ValidateWord;
   var
-    L : NativeInt;
+    L : Integer;
     W : Word;
   begin
     pbStripPicture(S, efEditSt);
@@ -2465,7 +2465,7 @@ var
 
   procedure ValidateInteger;
   var
-    L : NativeInt;
+    L : Integer;
     I : Integer;
   begin
     pbStripPicture(S, efEditSt);
@@ -2486,7 +2486,7 @@ var
 
   procedure ValidateByte;
   var
-    L : NativeInt;
+    L : Integer;
     B : Byte;
   begin
     pbStripPicture(S, efEditSt);
@@ -2507,7 +2507,7 @@ var
 
   procedure ValidateShortInt;
   var
-    L  : NativeInt;
+    L  : Integer;
     Si : ShortInt;
   begin
     pbStripPicture(S, efEditSt);

--- a/source/ovcrptvw.pas
+++ b/source/ovcrptvw.pas
@@ -5071,7 +5071,7 @@ end;
 
 procedure TOvcCustomReportView.MakeGroupVisible(GRef : TOvcRvIndexGroup);
 begin
-  PostMessage(Handle, OM_MakeGroupVisible, 0, Integer(GRef));
+  PostMessage(Handle, OM_MakeGroupVisible, 0, lParam(GRef));
 end;
 
 procedure TOvcCustomReportView.WMMakeGroupVisible(var Msg : TMessage);

--- a/source/ovcsf.pas
+++ b/source/ovcsf.pas
@@ -1014,7 +1014,7 @@ var
 
   procedure IncDecValueLongInt;
   var
-    L : NativeInt;
+    L : Integer;
   begin
     if efStr2Long(efEditSt, L) then begin
       if (Delta < 0) and (L <= efRangeLo.rtLong) then
@@ -1284,7 +1284,7 @@ var
   procedure TransferLongInt;
   begin
     if TransferFlag = otf_GetData then begin
-      if not efStr2Long(efEditSt, NativeInt(DataPtr^)) then
+      if not efStr2Long(efEditSt, Integer(DataPtr^)) then
         Integer(DataPtr^) := 0;
     end else
       efLong2Str(efEditSt, Integer(DataPtr^));
@@ -1292,7 +1292,7 @@ var
 
   procedure TransferWord;
   var
-    L : NativeInt;
+    L : Integer;
   begin
     if TransferFlag = otf_GetData then begin
       if efStr2Long(efEditSt, L) then
@@ -1305,7 +1305,7 @@ var
 
   procedure TransferInteger;
   var
-    L : NativeInt;
+    L : Integer;
   begin
     if TransferFlag = otf_GetData then begin
       if efStr2Long(efEditSt, L) then
@@ -1318,7 +1318,7 @@ var
 
   procedure TransferByte;
   var
-    L : NativeInt;
+    L : Integer;
   begin
     if TransferFlag = otf_GetData then begin
       if efStr2Long(efEditSt, L) then
@@ -1331,7 +1331,7 @@ var
 
   procedure TransferShortInt;
   var
-    L : NativeInt;
+    L : Integer;
   begin
     if TransferFlag = otf_GetData then begin
       if efStr2Long(efEditSt, L) then
@@ -1693,7 +1693,7 @@ var
 
   procedure ValidateLongInt;
   var
-    L : NativeInt;
+    L : Integer;
   begin
     if not efStr2Long(efEditSt, L) then
       Result := oeInvalidNumber
@@ -1710,7 +1710,7 @@ var
 
   procedure ValidateWord;
   var
-    L : NativeInt;
+    L : Integer;
   begin
     if not efStr2Long(efEditSt, L) then
       Result := oeInvalidNumber
@@ -1727,7 +1727,7 @@ var
 
   procedure ValidateInteger;
   var
-    L : NativeInt;
+    L : Integer;
     I : Integer;
   begin
     if not efStr2Long(efEditSt, L) then
@@ -1746,7 +1746,7 @@ var
 
   procedure ValidateByte;
   var
-    L : NativeInt;
+    L : Integer;
     B : Byte;
   begin
     if not efStr2Long(efEditSt, L) then
@@ -1765,7 +1765,7 @@ var
 
   procedure ValidateShortInt;
   var
-    L  : NativeInt;
+    L  : Integer;
     Si : ShortInt;
   begin
     if not efStr2Long(efEditSt, L) then

--- a/source/ovcslide.pas
+++ b/source/ovcslide.pas
@@ -113,8 +113,9 @@ type
     {dynamic event wrappers}
     procedure DoOnChange;
       virtual;
-    procedure DoOnMouseWheel(Shift : TShiftState; Delta, XPos, YPos : SmallInt);
-      override;
+    {DM - START CHANGE}
+    function DoMouseWheel(Shift: TShiftState; WheelDelta: integer; MousePos: TPoint): boolean; override;
+    {DM - END CHANGE}
 
 
     {properties}
@@ -282,12 +283,12 @@ end;
 
 procedure TOvcCustomSlider.CreateParams(var Params : TCreateParams);
 const
-  BorderStyles : array[TBorderStyle] of Integer = (0, WS_BORDER);
+  BorderStyles : array[TBorderStyle] of DWORD = (0, WS_BORDER);
 begin
   inherited CreateParams(Params);
 
   with Params do begin
-    Style := Integer(Style) or BorderStyles[FBorderStyle];
+    Style := DWORD(Style) or BorderStyles[FBorderStyle];
     if slPopup then begin
       Style := WS_POPUP or WS_BORDER;
       WindowClass.Style := WindowClass.Style or CS_SAVEBITS;
@@ -318,13 +319,15 @@ begin
     FOnChange(Self);
 end;
 
-procedure TOvcCustomSlider.DoOnMouseWheel(Shift : TShiftState; Delta, XPos, YPos : SmallInt);
+{DM - START CHANGE}
+function TOvcCustomSlider.DoMouseWheel(Shift: TShiftState; WheelDelta: integer; MousePos: TPoint): boolean;
 var
   Key : Word;
 begin
-  inherited DoOnMouseWheel(Shift, Delta, XPos, YPos);
+  result := inherited DoMouseWheel(Shift, WheelDelta, MousePos);
+  if result then Exit;
 
-  if Delta < 0 then
+  if WheelDelta < 0 then
     if (FOrientation = soHorizontal) then
       Key := VK_LEFT
     else
@@ -337,6 +340,7 @@ begin
 
   KeyDown(Key, []);
 end;
+{DM - END CHANGE}
 
 procedure TOvcCustomSlider.KeyDown(var Key : Word; Shift : TShiftState);
 begin

--- a/source/ovcspeed.pas
+++ b/source/ovcspeed.pas
@@ -841,7 +841,10 @@ begin
     end;
     if FAutoRepeat then begin
       if sbRepeatTimer = nil then
+      begin
         sbRepeatTimer := TTimer.Create(Self);
+        sbRepeatTimer.Enabled  := False;
+      end;
       sbRepeatTimer.Interval := FRepeatDelay;
       sbRepeatTimer.OnTimer := TimerExpired;
       sbRepeatTimer.Enabled  := True;

--- a/source/ovcsplit.pas
+++ b/source/ovcsplit.pas
@@ -335,7 +335,7 @@ procedure TOvcSplitter.CreateParams(var Params : TCreateParams);
 begin
   inherited CreateParams(Params);
 
-  Params.Style := Integer(Params.Style) or BorderStyles[FBorderStyle];
+  Params.Style := DWORD(Params.Style) or BorderStyles[FBorderStyle];
 end;
 
 procedure TOvcSplitter.CreateWnd;

--- a/source/ovctcedtHTMLText.pas
+++ b/source/ovctcedtHTMLText.pas
@@ -337,7 +337,7 @@ procedure TOvcTCHtmlTextEdit.WMKeyDown(var Msg : TWMKey);
     type
       LH = packed record L, H : word; end;
     var
-      GetSel : NativeInt;
+      GetSel : lResult;
     begin
       GetSel := SendMessage(Handle, EM_GETSEL, 0, 0);
       S := LH(GetSel).L;

--- a/source/ovctcedtTextFormatBar.pas
+++ b/source/ovctcedtTextFormatBar.pas
@@ -386,7 +386,7 @@ procedure TFormSubClasser.RevertParentWindowProc;
 begin
   if FForm <> nil then
   begin
-    if not RemoveWindowSubclass(FForm.Handle, SubClassWindowProc, NativeUInt(Self)) then
+    if not RemoveWindowSubclass(FForm.Handle, SubClassWindowProc, lParam(Self)) then
       RaiseLastOSError;
     FForm := nil;
   end;

--- a/source/ovctcell.pas
+++ b/source/ovctcell.pas
@@ -707,7 +707,7 @@ procedure TOvcBaseTableCell.SetTable(T : TOvcTableAncestor);
       if (not Assigned(T)) or (T is TOvcTableAncestor) then
         begin
           if Assigned(FTable) and FTable.HandleAllocated then
-            SendMessage(FTable.Handle, ctim_RemoveCell, 0, NativeInt(Self));
+            SendMessage(FTable.Handle, ctim_RemoveCell, 0, lParam(Self));
           FTable := T;
           FOnCfgChanged := nil;
           FReferences := 0;

--- a/source/ovctcstr.pas
+++ b/source/ovctcstr.pas
@@ -95,7 +95,7 @@ type
       { New property to access the new Field 'FEllipsisReadonly' together with 'FShowEllipsis'
         without changing 'ShowEllipsis' }
       property EllipsisMode: TEllipsisMode
-         read GetEllipsisMode write SetEllipsisMode default em_show_readonly;
+         read GetEllipsisMode write SetEllipsisMode default em_dont_show;
 
       property ShowEllipsis: Boolean read FShowEllipsis write FShowEllipsis;
 
@@ -116,7 +116,7 @@ implementation
 constructor TOvcTCBaseString.Create(AOwner : TComponent);
 begin
   inherited Create(AOwner);
-  FShowEllipsis := True;
+  FShowEllipsis := False;
   FEllipsisReadonly := True;
   FDataStringType := tstString;
   FIgnoreCR := True;
@@ -325,15 +325,16 @@ procedure TOvcTCBaseString.SetUseWordWrap(WW : boolean);
 
 function TOvcTCBaseString.ReadASCIIZStrings: boolean;
 begin
-  result := DataStringType = tstString;
+  result := DataStringType = tstPChar;
 end;
 
 procedure TOvcTCBaseString.SetUseASCIIZStrings(const Value: boolean);
 begin
   if Value then
-    DataStringType := tstString
-  else if FDataStringType=tstString then
-    DataStringType := tstShortString;
+    DataStringType := tstPChar
+  else
+  if DataStringType <> tstShortString then 
+    DataStringType := tstString;
 end;
 
 

--- a/source/ovcurl.pas
+++ b/source/ovcurl.pas
@@ -218,6 +218,7 @@ begin
         urlFontColor := Font.Color;
       Font.Color := FHighlightColor;
       urlTimer := TTimer.Create(Self);
+      urlTimer.Enabled := False;
       urlTimer.Interval := 100;
       urlTimer.OnTimer := TimerEvent;
       urlTimer.Enabled := True;

--- a/source/ovcvlb.pas
+++ b/source/ovcvlb.pas
@@ -62,7 +62,7 @@ const
   vlDefIntegralHeight  = True;
   vlDefItemIndex       = -1;
   vlDefMultiSelect     = False;
-  vlDefNumItems        = MaxLongInt;
+  vlDefNumItems        = MaxInt;
   vlDefOwnerDraw       = False;
   vlDefParentColor     = False;
   vlDefParentCtl3D     = True;
@@ -349,8 +349,9 @@ type
     function DoOnIsSelected(Index : Integer) : Boolean;
       virtual;
       {-call the OnIsSelected event, if assigned}
-    procedure DoOnMouseWheel(Shift : TShiftState; Delta, XPos, YPos : SmallInt);
-      override;
+    {DM - START CHANGE}
+    function DoMouseWheel(Shift: TShiftState; WheelDelta: integer; MousePos: TPoint): boolean; override;
+    {DM - END CHANGE}
     procedure DoOnSelect(Index : Integer; Selected : Boolean);
       dynamic;
       {-call the OnSelect event, if assigned}
@@ -786,20 +787,23 @@ begin
   end;
 end;
 
-procedure TOvcCustomVirtualListBox.DoOnMouseWheel(Shift : TShiftState; Delta, XPos, YPos : SmallInt);
+{DM - START CHANGE}
+function TOvcCustomVirtualListBox.DoMouseWheel(Shift: TShiftState; WheelDelta: integer; MousePos: TPoint): boolean;
 var
   I : Integer;
 begin
-  inherited DoOnMouseWheel(Shift, Delta, XPos, YPos);
+  result := inherited DoMouseWheel(Shift, WheelDelta, MousePos);
+  if result then Exit;
 
-  if Delta < 0 then begin
+  if WheelDelta < 0 then begin
     for I := 1 to {vlb}WheelDelta do
       Perform(WM_VSCROLL, MAKELONG(SB_LINEDOWN, 0), 0);
-  end else if Delta > 0 then begin
+  end else if WheelDelta > 0 then begin
     for I := 1 to {vlb}WheelDelta do
       Perform(WM_VSCROLL, MAKELONG(SB_LINEUP, 0), 0);
   end;
 end;
+{DM - END CHANGE}
 
 procedure TOvcCustomVirtualListBox.DoOnSelect(Index : Integer; Selected : Boolean);
   {-notify of selection change}
@@ -1439,7 +1443,7 @@ var
 begin
   if Value <> FNumItems then begin
     if (Value < 0) then
-      Value := MaxLongInt;
+      Value := MaxInt;
 
     OldNumItems := FNumItems;
     {set new item index}


### PR DESCRIPTION
-changed LongInt to Integer
-changed Integer to NativeInt when used to store reference or pointer
-changed Integer and NativeInt in Win32 API to correct type (lParam, wParam, lResult)
-changed SizeOf to Length when used with Char array
-fixed mouse wheel scroll - used VCL wheel events
-published Touch property