### PR TITLE
Fixed ReportView not printing all pages

### DIFF
--- a/source/ovcrptvw.pas
+++ b/source/ovcrptvw.pas
@@ -5632,11 +5632,11 @@ var
 begin
   Result := 0;
   LinesLeft := 0;
-  DoneSectionHeader := False;
-  DoneSectionFooter := False;
   for j := 0 to pred(Lines) do
     if not SelectedOnly or IsSelected[j] then begin
       while LinesLeft <= 0 do begin
+        DoneSectionHeader := False;
+        DoneSectionFooter := False;      
         inc(LinesLeft, (LinesPerPage - PrinterProperties.PrintHeaderLines - PrinterProperties.PrintFooterLines));
         inc(Result);
       end;


### PR DESCRIPTION
Originally CalcHPages() only counted the header and footer lines once per report instead of once per page.  This resulted in a wrong calculation of the number of pages to be printed if the reports were multiple pages long.