### PR TITLE
Fix TOvcCustomPictureField.CreateWnd so it retains string values

### DIFF
--- a/source/ovcpf.pas
+++ b/source/ovcpf.pas
@@ -311,7 +311,7 @@ begin
   if efSaveData then
   begin
     if efDataType mod fcpDivisor = fsubString then    //SZ
-      efTransfer(@S, otf_GetData)           //SZ
+      efTransfer(@S, otf_SetData)           //SZ
     else
       efTransfer(@P, otf_SetData);
   end;


### PR DESCRIPTION
If a TOvcCustomPictureField string value is set before the field is displayed then the string value is cleared in CreateWnd due to otf_GetData being used instead of otf_SetData. 